### PR TITLE
Format message timestamps as dates

### DIFF
--- a/apps/chat/components/chat/chat-message.tsx
+++ b/apps/chat/components/chat/chat-message.tsx
@@ -21,7 +21,7 @@ export interface ChatMessageProps {
   name: string
   player: any
   room: string
-  timestamp: number
+  timestamp: Date
   // user: User | null
 }
 
@@ -123,7 +123,7 @@ export function ChatMessage({
 
 export interface ChatMessageAudioProps {
   url: string
-  timestamp: number
+  timestamp: Date
 }
 
 export function ChatMessageAudio({
@@ -145,7 +145,7 @@ export function ChatMessageAudio({
 
 export interface ChatMessageVideoProps {
   url: string
-  timestamp: number
+  timestamp: Date
 }
 
 export function ChatMessageVideo({
@@ -167,7 +167,7 @@ export function ChatMessageVideo({
 
 export interface ChatMessageImageProps {
   url: string
-  timestamp: number
+  timestamp: Date
 }
 
 export function ChatMessageImage({

--- a/apps/chat/components/chat/chat.tsx
+++ b/apps/chat/components/chat/chat.tsx
@@ -37,7 +37,7 @@ type Message = {
 
   method: string
   name: string
-  timestamp: number
+  timestamp: Date
   userId: string
 }
 
@@ -69,15 +69,19 @@ export function Chat({ id, className, /* user, missingKeys, */ room }: ChatProps
   } = useMultiplayerActions()
 
   const messages = rawMessages.map((rawMessage: any, index: number) => {
+    const message = {
+      ...rawMessage,
+      timestamp: new Date(rawMessage.timestamp),
+    };
     // if (rawMessage.method === 'say') {
       return {
         id: index,
-        display: getMessageComponent(room, rawMessage, playersCache, sendRawMessage),
+        display: getMessageComponent(room, message, playersCache, sendRawMessage),
       };
     // } else {
     //   return null;
     // }
-  }).filter((message) => message !== null) as unknown as any[];
+  })/*.filter((message) => message !== null) as unknown */as any[];
 
   /*useEffect(() => {
     if (user) {


### PR DESCRIPTION
Fixes a crash where new agent timestamp format is a proper date string rather than a number.

The fix is to reify the raw messages to include a Date timestamp.