### PR TITLE
Multiplayer connected state tracking

### DIFF
--- a/apps/chat/components/chat/chat-history.tsx
+++ b/apps/chat/components/chat/chat-history.tsx
@@ -15,7 +15,7 @@ import { useMultiplayerActions } from '@/components/ui/multiplayer-actions';
 // }
 
 export function ChatHistory() {
-  const { getRoom, localPlayerSpec, playersMap, agentLeave } = useMultiplayerActions();
+  const { room, localPlayerSpec, playersMap, agentLeave } = useMultiplayerActions();
   const players = Array.from(playersMap.values()).sort((a, b) => {
     return a.getPlayerSpec().name.localeCompare(b.getPlayerSpec().name);
   });
@@ -51,8 +51,7 @@ export function ChatHistory() {
                 e.preventDefault();
                 e.stopPropagation();
 
-                const oldRoom = getRoom();
-                await agentLeave(playerSpec.id, oldRoom);
+                await agentLeave(playerSpec.id, room);
               }}
             >
               <IconClose className="stroke-2" />

--- a/apps/chat/components/prompt-form.tsx
+++ b/apps/chat/components/prompt-form.tsx
@@ -23,7 +23,7 @@ export function PromptForm({
 }) {
   const [mediaPickerOpen, setMediaPickerOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
-  const { sendChatMessage } = useMultiplayerActions()
+  const { connected, sendChatMessage } = useMultiplayerActions()
 
   const toggleMediaPicker = () => {
     setMediaPickerOpen(open => !open)
@@ -148,6 +148,7 @@ export function PromptForm({
           rows={1}
           value={input}
           onChange={e => setInput(e.target.value)}
+          disabled={!connected}
         />
         <div className="absolute right-0 top-[13px] sm:right-4">
           <Tooltip>

--- a/apps/chat/components/ui/multiplayer-actions.tsx
+++ b/apps/chat/components/ui/multiplayer-actions.tsx
@@ -79,7 +79,8 @@ const join = async ({
 //
 
 interface MultiplayerActionsContextType {
-  getRoom: () => string
+  connected: boolean
+  room: string
   getCrdtDoc: () => any
   localPlayerSpec: PlayerSpec
   playersMap: Map<string, Player>
@@ -444,6 +445,7 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
   const router = useRouter()
   const [epoch, setEpoch] = React.useState(0);
   const [multiplayerState, setMultiplayerState] = React.useState(() => {
+    let connected = false;
     let room = '';
     let realms: NetworkRealms | null = null;
     let localPlayerSpec: PlayerSpec = makeFakePlayerSpec();
@@ -474,6 +476,7 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
     };
 
     const multiplayerState = {
+      getConnected: () => connected,
       getRoom: () => room,
       getCrdtDoc: () => {
         // console.log('got realms 1', realms);
@@ -516,6 +519,18 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
             }
 
             realms = connectMultiplayer(room, newLocalPlayerSpec);
+            realms.addEventListener('connect', e => {
+              console.log('connect event');
+
+              connected = true;
+              refresh();
+            });
+            realms.addEventListener('disconnect', e => {
+              console.log('disconnect event');
+
+              connected = false;
+              refresh();
+            });
             realms.addEventListener('chat', (e) => {
               const { message } = (e as any).data;
               messages = [...messages, message];
@@ -581,7 +596,8 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
     };
     return multiplayerState;
   });
-  const getRoom = multiplayerState.getRoom;
+  const connected = multiplayerState.getConnected();
+  const room = multiplayerState.getRoom();
   const getCrdtDoc = multiplayerState.getCrdtDoc;
   const localPlayerSpec = multiplayerState.getLocalPlayerSpec();
   const playersMap = multiplayerState.getPlayersMap();
@@ -596,7 +612,8 @@ export function MultiplayerActionsProvider({ children }: MultiplayerActionsProvi
   return (
     <MultiplayerActionsContext.Provider
       value={{
-        getRoom,
+        connected,
+        room,
         getCrdtDoc,
         localPlayerSpec,
         playersMap,


### PR DESCRIPTION
Disables the chat room input form when the room is not connected.

This should help us debug worker disconnection issues.

Note that without this, you still can't chat when not connected. It would simply crash silently in the console.

In the future it makes sense to have the room connection state surfaced in some other way.