### PR TITLE
Comment dev unsupported commands

### DIFF
--- a/packages/sdk/cli.js
+++ b/packages/sdk/cli.js
@@ -2611,10 +2611,10 @@ const dev = async (args) => {
 
     //   break;
     // }
-    // case '': {
-    //   // nothing
-    //   break;
-    // }
+    case '': {
+      // nothing
+      break;
+    }
     default: {
       console.warn(`unknown subcommand: ${subcommand}`);
       process.exit(1);


### PR DESCRIPTION
Dev subcommands:

- ls, listen, fund and deposit are not supported in the first release roadmap

hence commenting them out for unwanted usage and wrong behaviours