### PR TITLE
Speaker output type fix

### DIFF
--- a/packages/sdk/sdk/src/devices/audio-output.mjs
+++ b/packages/sdk/sdk/src/devices/audio-output.mjs
@@ -13,14 +13,16 @@ export class SpeakerOutputStream extends WritableStream {
       //   controller = c;
       // },
       write: (chunk, controller) => {
-        // console.log('decode data 1', chunk);
-        // audioDecoder.decode(chunk);
-        // controller.enqueue(chunk);
-        this.speaker.write(chunk);
+        // console.log('speaker write', chunk);
+        let uint8Array;
+        if (chunk instanceof Uint8Array) {
+          uint8Array = chunk;
+        } else {
+          uint8Array = new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+        }
+        this.speaker.write(uint8Array);
       },
       close: async () => {
-        // audioDecoder.decode(null);
-        // await donePromise;
         this.speaker.end();
         await new Promise((accept, reject) => {
           this.speaker.once('finish', accept);


### PR DESCRIPTION
This PR attempts to fix the web streams pipe typing error seen by @AbdurrehmanSubhani.

I believe this was a type error where Int16Array is piped to the `SpeakerOutputStream`, and then the underlying `speaker.write` was not liking that typed array. I cast it to Uint8Array in this PR which seems like it would satisfy the nagging in the error.

I was not able to reproduce this issue but this PR doesn't crash so it's probably an OK change.

```
cli uncaught exception TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Int16Array
    at _write (node:internal/streams/writable:472:13)
    at Writable.write (node:internal/streams/writable:494:10)
    at Object.write (file:///Users/abdurrehmansubhani/Documents/GitHub/monorepo/packages/sdk/sdk/src/devices/audio-output.mjs:19:22)
    at ensureIsPromise (node:internal/webstreams/util:185:19)
    at writableStreamDefaultControllerProcessWrite (node:internal/webstreams/writablestream:1116:5)
    at writableStreamDefaultControllerAdvanceQueueIfNeeded (node:internal/webstreams/writablestream:1231:5)
    at writableStreamDefaultControllerWrite (node:internal/webstreams/writablestream:1105:3)
    at writableStreamDefaultWriterWrite (node:internal/webstreams/writablestream:995:3)
    at [kChunk] (node:internal/webstreams/readablestream:1554:31)
    at readableStreamFulfillReadRequest (node:internal/webstreams/readablestream:2096:24) {
  code: 'ERR_INVALID_ARG_TYPE'
} Promise {
  <rejected> TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Int16Array
      at _write (node:internal/streams/writable:472:13)
      at Writable.write (node:internal/streams/writable:494:10)
      at Object.write (file:///Users/abdurrehmansubhani/Documents/GitHub/monorepo/packages/sdk/sdk/src/devices/audio-output.mjs:19:22)
      at ensureIsPromise (node:internal/webstreams/util:185:19)
      at writableStreamDefaultControllerProcessWrite (node:internal/webstreams/writablestream:1116:5)
      at writableStreamDefaultControllerAdvanceQueueIfNeeded (node:internal/webstreams/writablestream:1231:5)
      at writableStreamDefaultControllerWrite (node:internal/webstreams/writablestream:1105:3)
      at writableStreamDefaultWriterWrite (node:internal/webstreams/writablestream:995:3)
      at [kChunk] (node:internal/webstreams/readablestream:1554:31)
      at readableStreamFulfillReadRequest (node:internal/webstreams/readablestream:2096:24) {
    code: 'ERR_INVALID_ARG_TYPE'
```