### PR TITLE
SDK: Double capability entries while creating agent using -t argument 

### DIFF
--- a/packages/sdk/cli.js
+++ b/packages/sdk/cli.js
@@ -2322,12 +2322,15 @@ const generateTemplateFromAgentJson = async (agentJson, {
 
     const importsHookRegex = /\/\* IMPORTS REGEX HOOK \*\//g;
     const impotsString = includedCapabilitySpecs.flatMap(capabilitySpec => capabilitySpec.imports).map(importName => `${importName},`).join(',');
-    agentJSX = agentJSX.replace(importsHookRegex, impotsString);
+    if (!agentJSX.includes(impotsString)) {
+      agentJSX = agentJSX.replace(importsHookRegex, impotsString);
+    }
 
     const jsxHookRegex = /\{\/\* JSX REGEX HOOK \*\/}/g;
     const jsxString = includedCapabilitySpecs.map(capabilitySpec => capabilitySpec.tsx).join('\n');
-    agentJSX = agentJSX.replace(jsxHookRegex, jsxString);
-
+    if (!agentJSX.includes(jsxString)) {
+      agentJSX = agentJSX.replace(jsxHookRegex, jsxString);
+    }
     await fs.promises.writeFile(agentJSXPath, agentJSX);
   }
 


### PR DESCRIPTION
fix for capabilities being added twice while agent creation using template

Fix:
Check for existing hook and jsx string while added to the agents agent.jsx file