### PR TITLE
support for 'usdk --version' command

### DIFF
--- a/packages/sdk/cli.js
+++ b/packages/sdk/cli.js
@@ -3866,6 +3866,9 @@ const main = async () => {
       }
     });
 
+  program
+  .version(packageJson.version);
+
   // misc
   program
     .command('version')


### PR DESCRIPTION
Add support for 'usdk --version', im used to get package versions using the --version arg so this would help users 