### PR TITLE
Fix agent not loading conversation messages

### DIFF
--- a/packages/sdk/sdk/src/classes/conversation-object.ts
+++ b/packages/sdk/sdk/src/classes/conversation-object.ts
@@ -12,6 +12,7 @@ import { SceneObject } from '../classes/scene-object';
 import { Player } from './player';
 import { ExtendableMessageEvent } from '../util/extendable-message-event';
 import { chatEndpointUrl } from '../util/endpoints.mjs';
+import { getChatKey } from './chats-manager';
 
 //
 
@@ -125,6 +126,15 @@ export class ConversationObject extends EventTarget {
   }
   removeAgent(agentId: string) {
     this.agentsMap.delete(agentId);
+  }
+
+  getKey() {
+    return getChatKey(
+      {
+        room: this.room,
+        endpointUrl: this.endpointUrl,
+      }
+    );
   }
 
   getCachedMessages(filter?: MessageFilter) {

--- a/packages/sdk/sdk/src/hooks.ts
+++ b/packages/sdk/sdk/src/hooks.ts
@@ -102,7 +102,7 @@ export const useCachedMessages = (opts?: ActionHistoryQuery) => {
     conversation.messageCache.loadPromise = (async () => {
       const messages = await loadMessagesFromDatabase({
         supabase,
-        conversationId: agent.id,
+        conversationId: conversation.getKey(),
         agentId: agent.id,
         limit: CACHED_MESSAGES_LIMIT,
       });

--- a/packages/sdk/sdk/src/types/agents.d.ts
+++ b/packages/sdk/sdk/src/types/agents.d.ts
@@ -207,6 +207,7 @@ export type ConversationObject = EventTarget & {
   getAgents: () => Player[];
   addAgent: (agentId: string, player: Player) => void;
   removeAgent: (agentId: string) => void;
+  getKey: () => string;
 };
 export type RoomSpecification = {
   room: string;


### PR DESCRIPTION
fix for using the correct conversationId while loading messages for a conversation

- Added a getter to the conversation object for getting the "key" for the conversation
- The key comprises of the endpoint url and the the roomId
- getter utilises a common function being used to set the conversation key

<img width="1440" alt="Screenshot 2024-08-27 at 11 31 14 AM" src="https://github.com/user-attachments/assets/af8f11d6-d5e8-4bde-a20c-a38c35f5375f">
