### PR TITLE
Fix start url missing in agent json

### DIFF
--- a/packages/sdk/cli.js
+++ b/packages/sdk/cli.js
@@ -472,6 +472,9 @@ const ensureAgentJsonDefaults = (spec) => {
   if (typeof spec.model !== 'string') {
     spec.model = generationModel;
   }
+  if (typeof spec.startUrl !== 'string') {
+    spec.startUrl = getCloudAgentHost(spec.id);
+  }
   if (typeof spec.previewUrl !== 'string') {
     spec.previewUrl = '/images/characters/upstreet/small/scillia.png';
   }


### PR DESCRIPTION
PR contains fix for agent's public page throwing error 404 agent not found