### PR TITLE
fix timeAgo calculation error throw

### DIFF
--- a/apps/chat/lib/utils.ts
+++ b/apps/chat/lib/utils.ts
@@ -108,4 +108,7 @@ export function isValidUrl(urlString: string) {
   return !!urlPattern.test(urlString);
 }
 
-export const timeAgo = (timestamp: Date) => jsAgo(+timestamp / 1000, { format: 'short' });
+export const timeAgo = (timestamp: Date) => {
+  const timestampInSeconds = Math.floor(timestamp.getTime() / 1000); // convert the timestamp to seconds since Unix epoch for better processing
+  return jsAgo(timestampInSeconds, { format: 'short' });
+}


### PR DESCRIPTION
fix for timeAgo calculation throwing timestamp in future error (diff in milli/microseconds)
<img width="1440" alt="Screenshot 2024-09-10 at 10 10 23 AM" src="https://github.com/user-attachments/assets/17d875f7-eaa2-4aa7-90ce-ff54a1fef486">

<img width="1440" alt="Screenshot 2024-09-10 at 10 29 34 AM" src="https://github.com/user-attachments/assets/31ddcf29-e7dc-493e-9c24-2d733f5150c3">
