### PR TITLE
fix for error while trying to format attachments "undefined"

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
@@ -803,8 +803,8 @@ export const ConversationMessagesPrompt = () => {
 export const CachedMessagesPrompt = () => {
   const cachedMessages = useCachedMessages();
 
-  const formatAttachments = (attachments: Attachment[]) => {
-    if (attachments && attachments.length > 0) {
+  const formatAttachments = (attachments?: Attachment[]) => {
+    if (attachments?.length > 0) {
       return attachments.map((attachment) => formatAttachment(attachment));
     } else {
       return undefined;


### PR DESCRIPTION
In case of no attachments ("undefined") .length throws error