### PR TITLE
add logout confirmation dialog to avoid logging out due to misclicks

### DIFF
--- a/apps/chat/components/account-button.tsx
+++ b/apps/chat/components/account-button.tsx
@@ -30,7 +30,11 @@ export function AccountButton({ user }: AccountButtonProps) {
       </Link>
       <a
         className="flex flex-row items-right p-2 h-full rounded text-sm cursor-pointer hover:bg-primary/10"
-        onClick={() => logout()}
+        onClick={() => {
+          if (window.confirm('Are you sure you want to logout?')) {
+        logout();
+          }
+        }}
       >
         <IconLogout className="mr-2 size-5" />
         <div className="hidden md:block">


### PR DESCRIPTION
Reason:
I was creating an agent and wanted to Start the agent but pressed Logout accidentally due to which i got logged out, lost the agent creation progress and had to go through the login flow again.

Hence imo having any confirmation dialog before processing the logout functionality will help avoid this entire scenario