### PR TITLE
invalid check, undefined "directory" causing empty args list to be sent

### DIFF
--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -3487,17 +3487,10 @@ const main = async () => {
         commandExecuted = true;
 
         let args;
-        if (typeof directory === 'string') {
-          args = {
-            _: [agentRefs],
-            ...opts,
-          };
-        } else {
-          args = {
-            _: [],
-            ...opts,
-          };
-        }
+        args = {
+          _: [agentRefs],
+          ...opts,
+        };
 
         await deploy(args);
       });


### PR DESCRIPTION
PR fixes ```usdk deploy``` command not utilising arguments passed