### PR TITLE
Ensure login tool does not throw error for current usdk login session 

### DIFF
--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -661,7 +661,7 @@ const login = async (args) => {
         } else {
           const host = local ? `http://local.upstreet.ai:${localPort}` : `https://login.upstreet.ai`;
           const u = new URL(`${host}/logintool`);
-          u.searchParams.set('callback_url', `https://local.upstreet.ai:${uniquePort}`);
+          u.searchParams.set('callback_url', `https://local.upstreet.ai:${randomPort}`);
           const p = u + '';
           console.log(`Waiting for login from ${p}`);
           open(p);


### PR DESCRIPTION
ensure a random port is assigned for login callback to ensure the current login session goes as expected
https://github.com/user-attachments/assets/82128d33-cf5c-422e-a52a-37500fcfa177

- Although the previously opened (unclosed logintool window) changes its state from Done to a fetch error, after making a new login attempt