### PR TITLE
Fix for "no jwt" error throw from "getVoiceStream" when in chat with an Agent

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/app-context-value.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/app-context-value.ts
@@ -234,6 +234,7 @@ export class AppContextValue {
         });
         const voiceEndpointVoicer = new VoiceEndpointVoicer({
           voiceEndpoint,
+          jwt: this.authToken,
           // audioManager: null,
           // sampleRate,
         });


### PR DESCRIPTION
fix jwt not supplied to the VoiceEndpointVoicer in app context causing "no jwt" error