### PR TITLE
Accounts search update

### DIFF
--- a/apps/chat/components/accounts/list/AccountRow.tsx
+++ b/apps/chat/components/accounts/list/AccountRow.tsx
@@ -35,7 +35,7 @@ export function AccountRow({ account }: AgentListProps) {
             <div className="font-bold text-lg line-clamp-1">{account.name}</div>
             <div className="line-clamp-3">{account.description}</div>
           </a>
-          <div className="text-center ml-6 absolute bottom-0 right-0">Agents: <span className="text-4xl">{account?.agents.length}</span></div>
+          <div className="text-center ml-6 absolute bottom-0 right-0">Agents: <span className="text-4xl">{account.agents_count}</span></div>
         </div>
       </div>
     </div>

--- a/apps/chat/components/accounts/list/index.tsx
+++ b/apps/chat/components/accounts/list/index.tsx
@@ -39,7 +39,8 @@ export function Accounts({ loadmore = false, range = 5 }: AgentsProps) {
 
     const { data, error } = await supabase
       .from('accounts')
-      .select('*, agents: assets(*)')
+      .select(`*`)
+      .gt('agent_count', 0)
       .ilike('name', `%${searchTerm}%`)
       .ilike('name', `%${debouncedSearchTerm}%`)
       .range(customRangeFrom, customRangeTo - 1)


### PR DESCRIPTION
## Filtered out the accounts that have no agents:

### Approach taken:
Added a new column `agent_count` to accounts table for 2 reasons, 1. Not to fetch the number of agents the account has created on search every time. 2. to filter out the accounts that don't have any. 

## How its updated:

### A database function is created to update the column:
```
BEGIN
  IF NEW.origin = 'sdk' THEN
    UPDATE accounts
    SET sdk_agents_count = (
      SELECT COUNT(*)
      FROM assets
      WHERE user_id = NEW.user_id AND origin = 'sdk'
    )
    WHERE id = NEW.user_id;
  END IF;
  RETURN NEW;
END;
```

### A trigger is created to trigger the function when an asset with origin set to SDK is added:

```
CREATE TRIGGER assets_insert_trigger
AFTER INSERT ON assets
FOR EACH ROW
EXECUTE FUNCTION update_sdk_agents_count();
```

