### PR TITLE
adjust code to proposed chat_specification changes

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/chats-specification.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/chats-specification.ts
@@ -120,8 +120,19 @@ export class ChatsSpecification extends EventTarget {
           const key = getRoomsSpecificationKey(roomSpecification);
           const result = await this.supabase.from('chat_specifications')
             .upsert({
-              id: key,
+              // id: key,
+              // the id column needs to be auto-generated as a unique uuid primary key instead of the "key"
+
               user_id: this.userId,
+
+              // XXX wip: restructre chat_specifications table to support multi agent rooms
+              /* 
+              add new roomId text column after making "id" column adjustments
+              to be used for supabase..delete(roomId) inside #leaveInternal
+
+              roomId: key, 
+              */
+              roomId: key,
               data: {
                 room: roomSpecification.room,
                 endpoint_url: roomSpecification.endpointUrl,
@@ -174,7 +185,9 @@ export class ChatsSpecification extends EventTarget {
           const key = getRoomsSpecificationKey(roomSpecification);
           const result = await this.supabase.from('chat_specifications')
             .delete()
-            .eq('id', key);
+            // .eq('id', key);
+            .eq('user_id', this.userId)
+            .eq('roomId', key); // roomId based deletion after restructuring chat_specifications table
           const {
             error,
           } = result;


### PR DESCRIPTION
Aims to fix the db upsertion error thrown for when:
- join request is sent to an agent where the room specified "key" is already existing (upserted by a previous agent which joined)

details: https://github.com/UpstreetAI/monorepo/issues/256#issue-2561352229

1. Restructure "id" column to be an auto-generated uuid column for primary key
2. Add new "roomId" column to the table for storing the room key
3. Adjust the #joinInternal supabase upsert code to upsert the roomId key rather then id
4. Adjust the #leaveInternal supabase delete code to delete based on roomId and user_id (both user_id and roomId to specifically delete the active agent's room and not all rows with the roomId)