### PR TITLE
Fix Agent chat message cache not working after rejoining same room in local env

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
@@ -140,7 +140,8 @@ export const useCachedMessages = (opts?: ActionHistoryQuery) => {
     })().catch((err) => {
       console.warn('message cache wait for load error', err);
     });
-  }, []);
+  }, [conversation]);
+
   // listen for messasge cache updates
   const update = (e: ExtendableMessageEvent<MessageCacheUpdateArgs>) => {
     setCachedMessagesEpoch(cachedMessagesEpoch => cachedMessagesEpoch + 1);
@@ -156,7 +157,7 @@ export const useCachedMessages = (opts?: ActionHistoryQuery) => {
     return () => {
       conversation.messageCache.removeEventListener('update', update);
     };
-  }, []);
+  }, [conversation]);
 
   const messages = conversation.getCachedMessages(opts?.filter);
   return messages;


### PR DESCRIPTION
PR includes fix for conversation message cache not loading and injecting messages to prompt after conversation removed and re-added.

Problem:
- The CachedMessagesPrompt component did not initialize properly when a conversation was added, removed, and then added again.
- This issue was caused by the hook not resetting its state when the conversation context changed.

Fix:
- Added "conversation" as dependancy to the messageCache loader useEffect
- Added "conversation" as dependancy to the messageCache listener's initialiser useEffect

