### PR TITLE
Wasm module fix

### DIFF
--- a/packages/usdk/usdk
+++ b/packages/usdk/usdk
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings
+#!/usr/bin/env -S node --no-warnings --experimental-wasm-modules
 
 // import './packages/cli/src/index.js'
 import './cli.js'


### PR DESCRIPTION
Adds `--experimental-wasm-modules` to the `usdk` command, so that importing `.wasm` files works.

This fixes the throw when importing `.wasm` files:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".wasm" for /Users/a/monorepo/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/multiplayer/public/audio-worker/mpg123-decoder/src/wasm-audio-decoder-common.wasm
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:218:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:244:36)
    at defaultLoad (node:internal/modules/esm/load:122:22)
    at async ModuleLoader.load (node:internal/modules/esm/loader:570:7)
    at async ModuleLoader.moduleProvider (node:internal/modules/esm/loader:443:45) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
```

This fixes the error but note that we hit another one:

```
avaer (you): Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'a' imported from /Users/a/monorepo/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/multiplayer/public/audio-worker/mpg123-decoder/src/emscripten-wasm.wasm
    at packageResolve (node:internal/modules/esm/resolve:839:9)
    at moduleResolve (node:internal/modules/esm/resolve:908:18)
    at defaultResolve (node:internal/modules/esm/resolve:1038:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:557:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:525:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:246:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}

```