### PR TITLE
Await User Input Before Generating Agent Data During Agent Creation

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-interview.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-interview.mjs
@@ -167,7 +167,7 @@ export class AgentInterview extends EventTarget {
           e.g. 'neotokyo, sakura trees, neon lights, path, ancient ruins, jungle, lush curved vine plants'
         ` + '\n\n' +
         featurePrompt +
-        (prompt ? ('The user has provided the following prompt:\n' + prompt) : ''),
+        (prompt ? ('The user has provided the following prompt:\n' + prompt) : 'No prompt provided by the user, you must await user\'s prompt before generating any agent data.'),
       object: agentJson,
       objectFormat: z.object({
         name: z.string().optional(),


### PR DESCRIPTION
Improve agent creation interview prompt to not generate data before user input