### PR TITLE
Auth host (instead of metamask)

### DIFF
--- a/apps/chat/utils/const/endpoints.js
+++ b/apps/chat/utils/const/endpoints.js
@@ -1,7 +1,7 @@
 export const aiHost = `https://ai.upstreet.ai`;
 export const aiProxyHost = `ai-proxy.isekaichat.workers.dev`;
 export const deployEndpointUrl = `https://deploy.upstreet.ai`;
-export const metamaskHost = 'https://metamask.upstreet.ai';
+export const authHost = 'https://auth.upstreet.ai';
 export const multiplayerEndpointUrl = 'wss://multiplayer.isekaichat.workers.dev';
 export const r2EndpointUrl = `https://r2.upstreet.ai`;
 export const loginEndpointUrl = `https://login.upstreet.ai/logintool`;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/endpoints.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/endpoints.mjs
@@ -1,6 +1,6 @@
 export const aiHost = `https://ai.upstreet.ai`;
 export const aiProxyHost = `ai-proxy.isekaichat.workers.dev`;
-export const metamaskHost = 'https://metamask.upstreet.ai';
+export const authHost = 'https://auth.upstreet.ai';
 export const multiplayerEndpointUrl = 'wss://multiplayer.isekaichat.workers.dev';
 export const deployEndpointUrl = `https://deploy.upstreet.ai`;
 export const r2EndpointUrl = `https://r2.upstreet.ai`;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/guid-util.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/guid-util.mjs
@@ -1,5 +1,5 @@
 import {
-  metamaskHost,
+  authHost,
 } from './endpoints.mjs';
 
 export const isGuid = (guid) => {
@@ -9,7 +9,7 @@ export const isGuid = (guid) => {
 export const createAgentGuid = async ({
   jwt,
 }) => {
-  const res = await fetch(`${metamaskHost}/createAgentGuid`, {
+  const res = await fetch(`${authHost}/createAgentGuid`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/jwt-utils.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/jwt-utils.mjs
@@ -1,9 +1,9 @@
 import {
-  metamaskHost,
+  authHost,
 } from './endpoints.mjs';
 
 export const getAgentToken = async (jwt, guid) => {
-  const jwtRes = await fetch(`${metamaskHost}/agent`, {
+  const jwtRes = await fetch(`${authHost}/agent`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Updates the domain for our authenticator to https://auth.upstreet.ai/

See:
- https://github.com/UpstreetAI/upstreet/pull/1415
- https://github.com/MetaMask/eth-phishing-detect/issues/89062