### PR TITLE
Add missing react-reconciler detachDeletedInstance handler

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/agent-renderer.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/agent-renderer.tsx
@@ -289,6 +289,9 @@ export class AgentRenderer {
       unhideTextInstance: (textInstance: TextInstance) => {
         textInstance.visible = true;
       },
+      detachDeletedInstance: (instance: Instance) => {
+        // console.log('detach deleted instance', [instance]);
+      },
       appendChild: (container: Instance, child: InstanceChild) => {
         container.children.push(child);
       },


### PR DESCRIPTION
Fix a race condition where missing react-reconciler `detachDeletedInstance` handler causes the agent to crash.

This [seems like it can be a noop](https://github.com/facebook/react/blob/1631855f4303cc8585205307a56c69e3b7248bb4/packages/react-native-renderer/src/ReactFiberConfigFabric.js#L532), but the reconciler does require it to be defined.