### PR TITLE
Fix multi chat join

### DIFF
--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -1345,29 +1345,23 @@ const chat = async (args) => {
   const jwt = await getLoginJwt();
   if (jwt !== null) {
     // start dev servers for the agents
-    const localRuntimePromises = agentSpecs
-      .map(async (agentSpec) => {
-        if (agentSpec.directory) {
-          const runtime = new ReactAgentsLocalRuntime(agentSpec);
-          await runtime.start({
-            debug,
-          });
-          return runtime;
-        } else {
-          return null;
-        }
-      })
-      .filter(Boolean);
-    const runtimes = await Promise.all(localRuntimePromises);
+    const runtimes = [];
+    for (const agentSpec of agentSpecs) {
+      if (agentSpec.directory) {
+      const runtime = new ReactAgentsLocalRuntime(agentSpec);
+      await runtime.start({
+        debug,
+      });
+      runtimes.push(runtime);
+      }
+    }
 
     // wait for agents to join the multiplayer room
-    await Promise.all(
-      agentSpecs.map(async (agentSpec) => {
-        await join({
-          _: [agentSpec.ref, room, agentSpec.portIndex],
-        });
-      }),
-    );
+    for (const agentSpec of agentSpecs) {
+      await join({
+      _: [agentSpec.ref, room, agentSpec.portIndex],
+      });
+    }
 
     // connect to the chat
     await connect({


### PR DESCRIPTION
- add support for passing in portIndex to parseAgentSpecs. Helps in nested parseAgentSpecs such as that in the 'chat' command. 
The issue currently was that since we're passing individual agentSpecs to join the portIndex for the >1 agents was being assigned "0" in the parseAgentSpecs function
- sequential agent dev server startup to ensure agent dev server is ready before sending join request