### PR TITLE
comment out leave all on sdk join call as it serves no use case

### DIFF
--- a/packages/usdk/packages/upstreet-agent/durable-object-impl.tsx
+++ b/packages/usdk/packages/upstreet-agent/durable-object-impl.tsx
@@ -477,9 +477,9 @@ export class DurableObjectImpl extends EventTarget {
             only = false,
           } = body ?? {};
           if (typeof room === 'string') {
-            if (only) {
-              await this.chatsSpecification.leaveAll();
-            }
+            // if (only) {
+            //   await this.chatsSpecification.leaveAll();
+            // }
 
             await this.chatsSpecification.join({
               room,


### PR DESCRIPTION
Remove/comment out .leaveAll() on sdk chat since it does not fulfil any requirement/use case