### PR TITLE
Fix sdk multi agent join

### DIFF
--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -1387,20 +1387,15 @@ const chat = async (args) => {
   const jwt = await getLoginJwt();
   if (jwt !== null) {
     // start dev servers for the agents
-    const localRuntimePromises = agentSpecs
-      .map(async (agentSpec) => {
-        if (agentSpec.directory) {
-          const runtime = new ReactAgentsLocalRuntime(agentSpec);
-          await runtime.start({
-            debug,
-          });
-          return runtime;
-        } else {
-          return null;
-        }
-      })
-      .filter(Boolean);
-    const runtimes = await Promise.all(localRuntimePromises);
+    
+    for (const agentSpec of agentSpecs) {
+      if (agentSpec.directory) {
+        const runtime = new ReactAgentsLocalRuntime(agentSpec);
+        await runtime.start({
+          debug,
+        });
+      }
+    }
 
     // wait for agents to join the multiplayer room
     const agentRefs = agentSpecs.map((agentSpec) => agentSpec.ref);


### PR DESCRIPTION
Contains fix for:

- join function call check for one agent spec, join not processing agentSpec array for making join calls
- sequential local agent dev server spin up to avoid join call and dev server sync issues