### PR TITLE
Login manual mode support

### DIFF
--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -362,75 +362,80 @@ const status = async (args) => {
 const login = async (args) => {
   const local = !!args.local;
 
-  let server = null;
-  let rl = null;
-  const handleLogin = async (j) => {
-    // close the server if it's still active
-    if (server) {
-      await server.close();
-      server = null;
-    }
-    // terminate the rl if it's still active
-    if (rl) {
-      console.log('*ok*');
-      rl.close();
-    }
-
-    const {
-      id,
-      jwt,
-    } = j;
-    await mkdirp(path.dirname(loginLocation));
-    await fs.promises.writeFile(loginLocation, JSON.stringify({
-      id,
-      jwt,
-    }));
-    console.log('Successfully logged in.');
-  };
-
   // if (!anonymous) {
     await new Promise((accept, reject) => {
+      let server = null;
+      let rl = null;
+      const handleLogin = async (j) => {
+        // close the server if it's still active
+        if (server) {
+          server.close();
+          server = null;
+        }
+        // terminate the rl if it's still active
+        if (rl) {
+          console.log('*ok*');
+          rl.close();
+        }
+    
+        const {
+          id,
+          jwt,
+        } = j;
+        await mkdirp(path.dirname(loginLocation));
+        await fs.promises.writeFile(loginLocation, JSON.stringify({
+          id,
+          jwt,
+        }));
+        console.log('Successfully logged in.');
+      };
+
       const serverOpts = getServerOpts();
+      const requestQueueManager = new QueueManager();
       server = https.createServer(serverOpts, (req, res) => {
-        // console.log('got login response 1', {
-        //   method: req.method,
-        //   url: req.url,
-        // });
+        requestQueueManager.waitForTurn(async () => {
+          if (server) {
+            // console.log('got login response 1', {
+            //   method: req.method,
+            //   url: req.url,
+            // });
 
-        // set cors
-        const corsHeaders = makeCorsHeaders(req);
-        for (const { key, value } of corsHeaders) {
-          res.setHeader(key, value);
-        }
+            // set cors
+            const corsHeaders = makeCorsHeaders(req);
+            for (const { key, value } of corsHeaders) {
+              res.setHeader(key, value);
+            }
 
-        // console.log('got login response 2', {
-        //   method: req.method,
-        //   url: req.url,
-        // });
+            // console.log('got login response 2', {
+            //   method: req.method,
+            //   url: req.url,
+            // });
 
-        // handle methods
-        if (req.method === 'OPTIONS') {
-          res.end();
-        } else if (req.method === 'POST') {
-          const bs = [];
-          req.on('data', (d) => {
-            bs.push(d);
-          });
-          req.on('end', async () => {
-            // respond to the page
-            res.end();
+            // handle methods
+            if (req.method === 'OPTIONS') {
+              res.end();
+            } else if (req.method === 'POST') {
+              const bs = [];
+              req.on('data', (d) => {
+                bs.push(d);
+              });
+              req.on('end', async () => {
+                // respond to the page
+                res.end();
 
-            const b = Buffer.concat(bs);
-            const s = b.toString('utf8');
-            const j = JSON.parse(s);
-            await handleLogin(j);
+                const b = Buffer.concat(bs);
+                const s = b.toString('utf8');
+                const j = JSON.parse(s);
+                await handleLogin(j);
 
-            accept();
-          });
-        } else {
-          res.statusCode = 405;
-          res.end();
-        }
+                accept();
+              });
+            } else {
+              res.statusCode = 405;
+              res.end();
+            }
+          }
+        });
       });
       // console.log('starting callback server on port', {
       //   callbackPort,


### PR DESCRIPTION
Update `usdk login` to support manual code entry from the login site. This is required to support remote server logins.

The localhost callback flow remains supported. If the localhost callback happens before manual entry then the login will succeed automatically. Otherwise the same flow is triggered with a manual code paste.