### PR TITLE
Fix base64ToUint8Array -> atob throwing error due to undefined string passed

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/kv.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/kv.ts
@@ -47,7 +47,7 @@ export class Kv<T> {
     const { error, data } = result;
     if (!error) {
       if (data) {
-        const base64Data = data.data as string;
+        const base64Data = data.value as string;
         const encodedData = base64ToUint8Array(base64Data);
         const value = zbdecode(encodedData);
         return value;


### PR DESCRIPTION
keys_values table does not have "data" column, has "value" hence use "value"

![image](https://github.com/user-attachments/assets/fb71f501-360a-4088-ae42-d10f825f38dd)
