### PR TITLE
Modulize usdk

### DIFF
--- a/packages/usdk/package.json
+++ b/packages/usdk/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.71",
   "author": "Upstreet",
   "type": "module",
+  "main": "module.mjs",
   "keywords": [
     "ai",
     "ai-agents",
@@ -28,6 +29,7 @@
     "util",
     "examples/**",
     "cli.js",
+    "module.mjs",
     "tsconfig.json"
   ],
   "dependencies": {


### PR DESCRIPTION
Fixes `usdk` not being importable as a module (it was only working on CLI mode).

This is necessary for `agent-deployer` and other use cases like the discord bot builder.