### PR TITLE
add missing Jimp and consoleImageWidth imports

### DIFF
--- a/packages/usdk/util/connect-utils.mjs
+++ b/packages/usdk/util/connect-utils.mjs
@@ -48,6 +48,8 @@ import {
 import {
   getLocalAgentHost,
 } from '../packages/upstreet-agent/packages/react-agents-wrangler/util/hosts.mjs';
+import Jimp from 'jimp';
+import { consoleImageWidth } from '../packages/upstreet-agent/packages/react-agents/constants.mjs';
 
 //
 


### PR DESCRIPTION
Fixes USDK chat crash on Agent generated image rendering

- adds missing imports

<img width="1016" alt="Screenshot 2024-11-07 at 4 35 58 PM" src="https://github.com/user-attachments/assets/2ca1748b-380a-4953-88de-97d85454f5ff">
