### PR TITLE
persist required agent vars in agent toml whilst edit completion

### DIFF
--- a/packages/usdk/lib/create.mjs
+++ b/packages/usdk/lib/create.mjs
@@ -653,8 +653,15 @@ export const edit = async (args, opts) => {
         const wranglerTomlPath = path.join(dstDir, 'wrangler.toml');
         await copyWithStringTransform(wranglerTomlPath, wranglerTomlPath, (s) => {
           let t = toml.parse(s);
+          const name = t.name;
+          const agentToken = t.vars.AGENT_TOKEN;
+          const mnemonic = t.vars.WALLET_MNEMONIC;
+
           t = buildWranglerToml(t, {
+            name,
             agentJson,
+            agentToken,
+            mnemonic,
           });
           return toml.stringify(t);
         });


### PR DESCRIPTION
This PR fixes issue:
https://github.com/orgs/UpstreetAI/projects/7/views/1?pane=issue&itemId=87056401&issue=UpstreetAI%7Cmonorepo%7C530

