### PR TITLE
chore: Update .gitignore to include wrangler.toml

### DIFF
--- a/packages/usdk/packages/upstreet-agent/.gitignore
+++ b/packages/usdk/packages/upstreet-agent/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# This is to protect secrets being exposed in a public git repo. Remove this on your own discretion.
+wrangler.toml


### PR DESCRIPTION
Just a safety protection mechanism for the hackathon participants. We can work on an .env based system afterwards.