### PR TITLE
extract playerId from e.data instead of player

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/chats-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/chats-manager.ts
@@ -172,9 +172,8 @@ export class ChatsManager {
       multiplayerConnection.addEventListener('connect', onConnect);
 
       multiplayerConnection.addEventListener('join', (e: any) => {
-        const { player } = e.data;
-        const { playerId } = player;
-        // console.log('chats specification: remote player joined:', playerId);
+        const { player, playerId } = e.data;
+        // console.log('chats specification: remote player joined:', playerId);h
 
         const remotePlayer = new Player(playerId, {});
         conversation.addAgent(playerId, remotePlayer);


### PR DESCRIPTION
Fix for issue:
https://github.com/orgs/UpstreetAI/projects/7/views/1?pane=issue&itemId=87203992&issue=UpstreetAI%7Cmonorepo%7C543

currently found that the playerId is present inside e.data