### PR TITLE
Add SelfConsciousReplies component for context aware message response ignore

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/generative-agent-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/generative-agent-object.ts
@@ -62,17 +62,19 @@ export class GenerativeAgentObject {
   }
   async complete(
     messages: ChatMessages,
+    model?: string,
   ) {
     return await this.agent.appContextValue.complete(messages, {
-      model: this.agent.model,
+      model: model ?? this.agent.model,
     });
   }
   async completeJson(
     messages: ChatMessages,
     format: ZodTypeAny,
+    model?: string,
   ) {
     return await this.agent.appContextValue.completeJson(messages, format, {
-      model: this.agent.model,
+      model: model ?? this.agent.model,
     });
   }
   async generateImage(prompt: string, opts?: SubtleAiImageOpts) {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
@@ -3373,12 +3373,12 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
     handler={async (e: AbortablePerceptionEvent) => {
       const { message, sourceAgent, targetAgent } = e.data;
 
-      console.log('SelfConsciousReplies', {
-        message,
-
-      });
+      // console.log('SelfConsciousReplies', {
+      //   message,
+      // });
 
       const conversationMembers = targetAgent.conversation.getAgents();
+      
       // Retrieve the most recent messages from conversation history, limited by historyLength,
       // and extract the relevant fields (name, text, timestamp) for each message
       const messages = targetAgent.conversation.getCachedMessages()
@@ -3418,19 +3418,23 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
           
           2. Only interrupt conversations between others in rare and justified cases. Your confidence should be very low (< 0.3) 
              if you're considering responding to a message not directed at you.
+
+          3. If the message appears to be directed to the entire group or is a general statement/question:
+             - You should be highly interested in participating
+             - Your confidence should be high (> 0.7) as group discussions warrant active participation
+             - Consider the value you can add to the group conversation
           
-          3. Message frequency control:
-             - Check how many messages you've sent recently in the conversation history
-             - If you've sent multiple messages in the last few exchanges, lower your confidence significantly
-             - Avoid dominating the conversation - others should have space to participate
-             - Consider staying silent if you've been very active recently, unless you have highly relevant or critical information to share
+          4. Message frequency suggestions:
+             - Reduce participation if you've sent 3+ messages in immediate succession
+             - Focus on the value of your contribution rather than how recently you've spoken
+             - Don't worry too much about "dominating" the conversation unless you're the only one talking
           
           Additional considerations:
           - Is the message explicitly directed at you? (Weight: ${defaultThreshold})
+          - Is the message directed to everyone in the group? (High priority)
           - Would responding align with ONLY your defined personality traits?
           - Is your response truly necessary or would it derail the current conversation?
           - Are you certain you have unique, valuable information to add if interrupting?
-          - Have you been contributing too frequently to the conversation lately?
           
           Respond with a decision object containing:
           - shouldRespond: boolean (true if confidence > ${defaultThreshold})
@@ -3451,7 +3455,7 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
         'openai:gpt-4o-mini',
         );
 
-        console.log('decision', decision);
+        // console.log('decision', decision);
         // console.log(`Agent ${targetAgent.agent.name} decision: ${decision.content.shouldRespond ? 'respond' : 'not respond'} - ${decision.content.reason} (confidence: ${decision.content.confidence})`);
 
         if (!decision.content.shouldRespond || decision.content.confidence < defaultThreshold) {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
@@ -142,6 +142,7 @@ export const DefaultAgentComponents = () => {
       {/* <LiveMode /> */}
       <DefaultPrompts />
       {/* <DefaultServers /> */}
+      <SelfConsciousReplies historyLength={15} defaultThreshold={0.6} />
     </>
   );
 };

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
@@ -3378,7 +3378,8 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
 
       });
 
-      // Get conversation history
+      // Retrieve the most recent messages from conversation history, limited by historyLength,
+      // and extract the relevant fields (name, text, timestamp) for each message
       const messages = targetAgent.conversation.getCachedMessages()
           .slice(-historyLength)
           .map(m => ({
@@ -3397,21 +3398,40 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
           Recent conversation history:
           ${messages.map(m => `${m.name}: ${m.text}`).join('\n')}
           
-          Your personality: ${targetAgent.agent.bio}
+          Your personality (ONLY use this information to guide your response, do not make assumptions beyond it):
+          ${targetAgent.agent.bio}
           Your name: ${targetAgent.agent.name}
+          Your id: ${targetAgent.agent.id}
           
           Other users mentioned in the current message: ${extractMentions(message?.args?.text || '').join(', ')}
           
           Based on this context, should you respond to this message?
-          Consider:
-          1. Is the message directed at you specifically? (Weight: ${defaultThreshold})
-          2. Is the conversation active and engaging?
-          3. Would responding align with your personality?
-          4. Are other users being addressed instead of you?
+          
+          IMPORTANT GUIDELINES:
+          1. If the message is clearly addressed to someone else (via @mention or context), you should NOT respond UNLESS:
+             - You have critical information that directly relates to the message and would be valuable to share
+             - The information is urgent or important enough to justify interrupting
+             - Not sharing this information could lead to misunderstandings or issues
+          
+          2. Only interrupt conversations between others in rare and justified cases. Your confidence should be very low (< 0.3) 
+             if you're considering responding to a message not directed at you.
+          
+          3. Message frequency control:
+             - Check how many messages you've sent recently in the conversation history
+             - If you've sent multiple messages in the last few exchanges, lower your confidence significantly
+             - Avoid dominating the conversation - others should have space to participate
+             - Consider staying silent if you've been very active recently, unless you have highly relevant or critical information to share
+          
+          Additional considerations:
+          - Is the message explicitly directed at you? (Weight: ${defaultThreshold})
+          - Would responding align with ONLY your defined personality traits?
+          - Is your response truly necessary or would it derail the current conversation?
+          - Are you certain you have unique, valuable information to add if interrupting?
+          - Have you been contributing too frequently to the conversation lately?
           
           Respond with a decision object containing:
           - shouldRespond: boolean (true if confidence > ${defaultThreshold})
-          - reason: brief explanation
+          - reason: brief explanation including specific justification if interrupting others' conversation
           - confidence: number between 0-1
         `;
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
@@ -3378,6 +3378,7 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
 
       });
 
+      const conversationMembers = targetAgent.conversation.getAgents();
       // Retrieve the most recent messages from conversation history, limited by historyLength,
       // and extract the relevant fields (name, text, timestamp) for each message
       const messages = targetAgent.conversation.getCachedMessages()
@@ -3394,6 +3395,8 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
           
           Current message: "${message?.args?.text || ''}"
           From user: ${sourceAgent.name}
+
+          Conversation members: ${conversationMembers.map(a => `${a.playerSpec.name} (${a.playerSpec.id})`).join(', ')}
           
           Recent conversation history:
           ${messages.map(m => `${m.name}: ${m.text}`).join('\n')}

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/default-components.tsx
@@ -3424,7 +3424,9 @@ export const SelfConsciousReplies: React.FC<SelfConsciousRepliesProps> = (props:
         const decision = await targetAgent.completeJson([{
           role: 'assistant',
           content: decisionPrompt,
-        }], decisionSchema);
+        }], decisionSchema,
+        'openai:gpt-4o-mini',
+        );
 
         console.log('decision', decision);
         // console.log(`Agent ${targetAgent.agent.name} decision: ${decision.content.shouldRespond ? 'respond' : 'not respond'} - ${decision.content.reason} (confidence: ${decision.content.confidence})`);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
@@ -52,10 +52,12 @@ export type GenerativeAgentObject =  {
   embed: (text: string) => Promise<Array<number>>;
   complete: (
     messages: ChatMessages,
+    model?: string,
   ) => Promise<ChatMessage>;
   completeJson: (
     messages: ChatMessages,
     format: ZodTypeAny,
+    model?: string,
   ) => Promise<ChatMessage>;
 
   think: (hint?: string, thinkOpts?: AgentThinkOptions) => Promise<any>;


### PR DESCRIPTION
This PR adds a SelfConsciousReplies to the DefaultComponents of an Agent.

The SelfConsciousReplies component is a PerceptionModifier which is aimed to provide the agent with the capability of choosing not reply to an incoming "say" perception based on the following parameters:

- Conversation chat history context
- Conversation Members
- Prev 6 messages to check if the agent has been back and forth (helps to reduce agent's interest in the conversation)
- Agent's personality (bio)
- Set of guidelines for the Agent to consider provided the context above

Currently getting in response to the thinking process above the following schema:
-  shouldRespond: boolean
- reason: string (this is for helping debugging cases in the future to see what the thought process was and how the prompt can be improved later on)
- confidence: number (the overall confidence score the Agent thinks it has to send a reply to this message)

If the agent has been back and forth in the conversation a lot, a backAndForthPenalty is applied to the agent's reply reasoning to lower down its overall confidence for replying to this message