### PR TITLE
Add VAD to Buffered audio streams to enhance voice integration

### DIFF
--- a/packages/usdk/lib/create.mjs
+++ b/packages/usdk/lib/create.mjs
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 import { mkdirp } from 'mkdirp';
 import pc from 'picocolors';
-import Jimp from 'jimp';
+import { Jimp } from 'jimp';
 import ansi from 'ansi-escapes';
 import toml from '@iarna/toml';
 import { cleanDir } from '../lib/directory-util.mjs';

--- a/packages/usdk/package.json
+++ b/packages/usdk/package.json
@@ -76,7 +76,7 @@
     "hono": "^4.6.9",
     "javascript-time-ago": "^2.5.11",
     "jest": "^29.7.0",
-    "jimp": "^0.22.12",
+    "jimp": "^1.6.0",
     "jszip": "^3.10.1",
     "lamejs": "file:./packages/upstreet-agent/packages/codecs/packages/lamejs",
     "libopusjs": "file:./packages/upstreet-agent/packages/codecs/packages/libopusjs",

--- a/packages/usdk/packages/upstreet-agent/package.json
+++ b/packages/usdk/packages/upstreet-agent/package.json
@@ -16,7 +16,7 @@
     "ethers": "^6.12.0",
     "format-util": "^1.0.5",
     "javascript-time-ago": "^2.5.11",
-    "jimp": "^0.22.12",
+    "jimp": "^1.6.0",
     "memoize-one": "^6.0.0",
     "minimatch": "^9.0.4",
     "openai": "^4.56.0",

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -67,13 +67,25 @@ const bindOutgoing = ({
       message,
     } = e.data;
     const {
+      attachments,
+    } = message;
+    const {
       method,
       args,
     } = message;
+
     if (method === 'say') {
-      const {
+      let {
         text,
       } = args as { text: string };
+      
+      if (attachments && Object.keys(attachments).length > 0) {
+        text += '\n' + Object.values(attachments)
+          .filter(attachment => attachment && typeof attachment === 'object' && 'url' in attachment)
+          .map(attachment => attachment.url)
+          .join('\n');
+      }
+
       discordBotClient.input.writeText(text, {
         channelId,
         userId,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/devices/video-input.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/devices/video-input.mjs
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import child_process from 'child_process';
-import Jimp from 'jimp';
-const { intToRGBA } = Jimp;
+import { Jimp } from 'jimp';
+import { intToRGBA } from '@jimp/utils';
 import chalk from 'chalk';
 import ansiEscapeSequences from 'ansi-escape-sequences';
 import { QueueManager } from 'queue-manager';
@@ -79,7 +79,7 @@ export class ImageRenderer {
 
       const {width, height} = calculateWidthHeight(bitmap.width, bitmap.height, inputWidth, inputHeight, preserveAspectRatio);
 
-      image.resize(width, height);
+      image.resize({w: width, h: height});
 
       let result = '';
       for (let y = 0; y < image.bitmap.height - 1; y += 2) {
@@ -95,7 +95,7 @@ export class ImageRenderer {
       return result;
     }
 
-    const image = new Jimp(imageData.width, imageData.height);
+    const image = new Jimp({width: imageData.width, height: imageData.height});
     image.bitmap.data.set(imageData.data);
     const text = render(image, {
       width,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
@@ -64,8 +64,8 @@ export const defaultVoices = [
   },
 ];
 
-const formatDiscordBotChannels = (channels = '') => {
-  return channels.split(',').map(c => c.trim()).filter(Boolean);
+const formatDiscordBotChannels = (channels = []) => {
+  return channels.map(c => c.trim()).filter(Boolean);
 };
 
 export const featureSpecs = [
@@ -162,7 +162,7 @@ export const featureSpecs = [
       if (discord.token && channels.length > 0) {
         return [
           dedent`
-            <DiscordBot
+            <Discord
               token=${JSON.stringify(discord.token)}
               ${discord.channels ? `channels={${JSON.stringify(channels)}}` : ''}
             />

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/generate-video.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/generate-video.mjs
@@ -1,5 +1,5 @@
 import { aiProxyHost } from './endpoints.mjs';
-import Jimp from 'jimp';
+import { Jimp } from 'jimp';
 
 const blob2jimp = async (blob) => {
   const arrayBuffer = await blob.arrayBuffer();
@@ -26,9 +26,7 @@ export const generateVideo = async (imageBlob, {
     throw new Error('no jwt');
   }
 
-  // resize the image blob using jimp
-  // the available sizes are 1024x576 or 576x1024 or 768x768
-  // console.log('load blob 1', imageBlob);
+  // Resize image to required dimensions
   const dimensions = {
     width: 768,
     height: 768,
@@ -36,75 +34,83 @@ export const generateVideo = async (imageBlob, {
   const image = await blob2jimp(imageBlob);
   // resize to the needed size
   // console.log('load blob 2', image);
-  image.resize(dimensions.width, dimensions.height);
+  image.resize({ w: dimensions.width, h: dimensions.height });
   console.log('load blob 3', image);
   // const resizedImage = await resizeImageBlob(image, 768, 768);
   const imageBlob2 = await jimp2blob(image, {
     type: 'image/jpeg',
   });
-  console.log('load blob 4', imageBlob2);
 
+  // Submit image for video generation
   const fd = new FormData();
   fd.append('image', imageBlob2);
   const res = await fetch(`https://${aiProxyHost}/api/ai/image-to-video`, {
     method: 'POST',
-
     headers: {
       Authorization: `Bearer ${jwt}`,
     },
-
     body: fd,
   });
-  // console.log('generate model req', res.ok, res.headers);
-  if (res.ok) {
-  // console.log('generate model blob 0');
-    const j = await res.json();
-    const { id } = j;
-    const loadPromise = (async () => {
-      const pollTime = 1000;
-      const result = await new Promise((accept, reject) => {
-        console.log('video load promise 0');
-        const check = async () => {
-          console.log('video load promise tick 1', {
-            id,
-          });
 
-          const res2 = await fetch(`https://${aiProxyHost}/api/ai/image-to-video/result/${id}`, {
-            headers: {
-              Authorization: `Bearer ${jwt}`,
-              Accept: 'video/*',
-            },
-          });
-          const blob = await res2.blob();
-          if (blob.type === 'application/json') {
-            const s = await blob.text();
-            const j = JSON.parse(s);
-            console.log('got json', j);
-            timeout = setTimeout(check, pollTime);
-          } else {
-            console.log('got non-json, returning it as the media blob', blob);
-            accept(blob);
-            clearTimeout(timeout);
-            timeout = null;
-          }
-          console.log('video load promise tick 3', { id, blob });
-          // https://platform.stability.ai/account/credits
-        };
-        let timeout = setTimeout(check, pollTime);
-      });
-      return result;
-    })();
-    // const waitForLoad = () => loadPromise;
-    // return {
-    //   id,
-    //   waitForLoad,
-    // };
-    return await loadPromise;
-    // const blob = await res.blob();
-    // // console.log('generate model blob 2');
-    // return blob;
-  } else {
+  if (!res.ok) {
     const text = await res.text();
-    throw new Error('invalid status code: ' + res.status + ': ' + text);
+    throw new Error(`Invalid status code: ${res.status}: ${text}`);
   }
+
+  const { id } = await res.json();
+  
+  // Poll for results
+  const pollTime = 1000;
+  const maxAttempts = 60;
+  let attempts = 0;
+  let timeout;
+
+  return new Promise((resolve, reject) => {
+    const check = async () => {
+      if (attempts++ >= maxAttempts) {
+        clearTimeout(timeout);
+        reject(new Error('Timeout waiting for video generation'));
+        return;
+      }
+
+      try {
+        const res2 = await fetch(`https://${aiProxyHost}/api/ai/image-to-video/result/${id}`, {
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+            Accept: 'video/*',
+          },
+        });
+
+        if (!res2.ok) {
+          timeout = setTimeout(check, pollTime);
+          return;
+        }
+
+        if (res2.status === 202) {
+          try {
+            const progressData = await res2.json();
+            console.log('Generation in progress:', progressData);
+          } catch (e) {} // Ignore progress parse errors
+          
+          timeout = setTimeout(check, pollTime);
+          return;
+        }
+
+        const contentType = res2.headers.get('content-type');
+        if (contentType?.includes('video/')) {
+          const blob = await res2.blob();
+          clearTimeout(timeout);
+          resolve(blob);
+          return;
+        }
+
+        timeout = setTimeout(check, pollTime);
+      } catch (err) {
+        console.error('Error checking video status:', err);
+        timeout = setTimeout(check, pollTime);
+      }
+    };
+
+    timeout = setTimeout(check, pollTime);
+  });
 };

--- a/packages/usdk/util/connect-utils.mjs
+++ b/packages/usdk/util/connect-utils.mjs
@@ -50,7 +50,7 @@ import {
 import {
   getLocalAgentHost,
 } from '../packages/upstreet-agent/packages/react-agents-wrangler/util/hosts.mjs';
-import Jimp from 'jimp';
+import { Jimp } from 'jimp';
 import { consoleImageWidth } from '../packages/upstreet-agent/packages/react-agents/constants.mjs';
 
 //


### PR DESCRIPTION
This branch is rebased from:

- Discord component updates:
https://github.com/UpstreetAI/upstreet-core/pull/636

- Voice Data Buffering: Combine Fragmented Discord Voice Streams for Better Transcription:
https://github.com/UpstreetAI/upstreet-core/pull/648

It then adds the following:

- Adds VAD to the Agent's discord-client, which initialises a websocket connection with our deployed realtime vad implementation
- Audio flow:
  1. Raw Discord voice packets are collected in `#activeVoiceBuffer`
  2. Each packet is converted from Opus to PCM using a queued decoder
  3. PCM data is resampled to 16kHz and sent to VAD service
  4. VAD service responds with speech/non-speech events
  5. Only audio segments marked as speech are processed and forwarded
- Added idle timeout (1000ms) to handle end of speech segments