### PR TITLE
allow all ancestor origins for testing

### DIFF
--- a/apps/chat/next.config.js
+++ b/apps/chat/next.config.js
@@ -87,4 +87,17 @@ module.exports = {
 
     return config;
   },
+  async headers() {
+    return [
+      {
+        source: "/embed/:id",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors *;",
+          },
+        ],
+      },
+    ];
+  },
 }


### PR DESCRIPTION
- allows the /embed route pass the CSP, testing live