### PR TITLE
feat(docs): add llms txt

### DIFF
--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,0 +1,65 @@
+import * as fs from 'node:fs/promises';
+import fg from 'fast-glob';
+import matter from 'gray-matter';
+import path from 'node:path';
+import { remark } from 'remark';
+// import remarkGfm from 'remark-gfm';
+import {
+  fileGenerator,
+  remarkDocGen,
+  remarkInstall,
+  typescriptGenerator,
+} from 'fumadocs-docgen';
+import remarkStringify from 'remark-stringify';
+import remarkMdx from 'remark-mdx';
+
+export const revalidate = false;
+
+export async function GET() {
+  const files = await fg([
+    './content/docs/**/*.mdx',
+    '!*.model.mdx',
+    '!./content/docs/openapi/**/*',
+  ]);
+
+  const scan = files.map(async (file) => {
+    const fileContent = await fs.readFile(file);
+    const { content, data } = matter(fileContent.toString());
+
+    const dir = path.dirname(file).split(path.sep).at(3);
+    const category = {
+      ui: 'Fumadocs Framework',
+      headless: 'Fumadocs Core (core library of framework)',
+      mdx: 'Fumadocs MDX (the built-in content source)',
+      cli: 'Fumadocs CLI (the CLI tool for automating Fumadocs apps)',
+    }[dir ?? ''];
+
+    if (data._mdx?.mirror) {
+      return;
+    }
+
+    const processed = await processContent(content);
+    return `file: ${file}
+# ${category}: ${data.title}
+
+${data.description}
+        
+${processed}`;
+  });
+
+  const scanned = await Promise.all(scan);
+
+  return new Response(scanned.join('\n\n'));
+}
+
+async function processContent(content: string): Promise<string> {
+  const file = await remark()
+    .use(remarkMdx)
+    // .use(remarkGfm)
+    .use(remarkDocGen, { generators: [typescriptGenerator(), fileGenerator()] })
+    .use(remarkInstall, { persist: { id: 'package-manager' } })
+    .use(remarkStringify)
+    .process(content);
+
+  return String(file);
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -12,6 +12,7 @@
     "esbuild": "0.24.0",
     "framer-motion": "^11.11.9",
     "fumadocs-core": "14.0.2",
+    "fumadocs-docgen": "^1.3.2",
     "fumadocs-mdx": "11.0.0",
     "fumadocs-ui": "14.0.2",
     "next": "14.2.14",
@@ -28,6 +29,8 @@
     "typescript": "^5.6.3"
   },
   "optionalDependencies": {
+    "@esbuild/darwin-arm64": "0.24.0",
+    "@esbuild/linux-x64": "0.24.0",
     "@next/swc-darwin-arm64": "15.0.1",
     "@next/swc-darwin-x64": "15.0.1",
     "@next/swc-linux-arm64-gnu": "15.0.1",
@@ -36,8 +39,6 @@
     "@next/swc-linux-x64-musl": "15.0.1",
     "@next/swc-win32-arm64-msvc": "15.0.1",
     "@next/swc-win32-ia32-msvc": "15.0.1",
-    "@next/swc-win32-x64-msvc": "15.0.1",
-    "@esbuild/linux-x64": "0.24.0",
-    "@esbuild/darwin-arm64": "0.24.0"
+    "@next/swc-win32-x64-msvc": "15.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
         "esbuild": "0.24.0",
         "framer-motion": "^11.11.9",
         "fumadocs-core": "14.0.2",
+        "fumadocs-docgen": "^1.3.2",
         "fumadocs-mdx": "11.0.0",
         "fumadocs-ui": "14.0.2",
         "next": "14.2.14",
@@ -23614,6 +23615,20 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
@@ -25074,6 +25089,48 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/fumadocs-docgen": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fumadocs-docgen/-/fumadocs-docgen-1.3.2.tgz",
+      "integrity": "sha512-+tVlkHIdpp893bRqr+xtCae2eirssg/hxUjc4/BEbV6RSxZ+Rx6CQUPWuYPw0C+/rEsvedLPQi+Py72zOm+uBA==",
+      "license": "MIT",
+      "dependencies": {
+        "estree-util-value-to-estree": "^3.1.2",
+        "fumadocs-typescript": "^3.0.2",
+        "hast-util-to-estree": "^3.1.0",
+        "npm-to-yarn": "^3.0.0",
+        "ts-morph": "^24.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/fumadocs-docgen/node_modules/@ts-morph/common": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.25.0.tgz",
+      "integrity": "sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^9.0.4",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.9"
+      }
+    },
+    "node_modules/fumadocs-docgen/node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
+    },
+    "node_modules/fumadocs-docgen/node_modules/ts-morph": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-24.0.0.tgz",
+      "integrity": "sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.25.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
     "node_modules/fumadocs-mdx": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/fumadocs-mdx/-/fumadocs-mdx-11.0.0.tgz",
@@ -25124,6 +25181,204 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/fumadocs-typescript": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fumadocs-typescript/-/fumadocs-typescript-3.0.2.tgz",
+      "integrity": "sha512-SqYJy+NxjjuQQeom7wLpODYiWtIKWfndguHL3XKXaMUvhlsjmsWWTaXJWKaqIfOStiYJQlGWrXxFA2Rrpbx63Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "22.8.1",
+        "fast-glob": "^3.3.1",
+        "hast-util-to-jsx-runtime": "^2.3.2",
+        "mdast-util-from-markdown": "^2.0.2",
+        "mdast-util-gfm": "^3.0.0",
+        "mdast-util-to-hast": "^13.2.0",
+        "shiki": "^1.22.2",
+        "ts-morph": "^24.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/@ts-morph/common": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.25.0.tgz",
+      "integrity": "sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^9.0.4",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.9"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/@types/node": {
+      "version": "22.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.1.tgz",
+      "integrity": "sha512-k6Gi8Yyo8EtrNtkHXutUu2corfDf9su95VYVP10aGYMMROM6SAItZi0w1XszA6RtWTHSVp5OeFof37w0IEqCQg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
+    },
+    "node_modules/fumadocs-typescript/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
+      "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/mdast-util-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
+      "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/mdast-util-gfm-footnote": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
+      "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/ts-morph": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-24.0.0.tgz",
+      "integrity": "sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.25.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
+    "node_modules/fumadocs-typescript/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/fumadocs-ui": {
@@ -35773,6 +36028,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm-to-yarn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-to-yarn/-/npm-to-yarn-3.0.0.tgz",
+      "integrity": "sha512-76YnmsbfrYp0tMsWxM0RNX0Vs+x8JxpJGu6B/jDn4lW8+laiTcKmKi9MeMh4UikO4RkJ1oqURoDy9bXJmMXS6A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/nebrelbug/npm-to-yarn?sponsor=1"
+      }
+    },
     "node_modules/npmlog": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
@@ -43965,6 +44232,19 @@
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",


### PR DESCRIPTION
Inspired by:
- Fumadocs: https://github.com/fuma-nama/fumadocs/blob/dev/apps/docs/app/llms-full.txt/route.ts
- FireCrawl: https://llmstxt.firecrawl.dev/

Why for docs?
Because that way other LLMs can learn about this Agentic framework and refer it :D