### PR TITLE
fix: add path fallback

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/codecs/packages/libopusjs/libopus.wasm.fs.js
+++ b/packages/usdk/packages/upstreet-agent/packages/codecs/packages/libopusjs/libopus.wasm.fs.js
@@ -8,7 +8,7 @@ const loadWasm = p => {
   return m;
 };
 
-let dirname = getCurrentDirname(import.meta);
+let dirname = getCurrentDirname(import.meta, process);
 const wasm = loadWasm(path.join(dirname, '/libopus.wasm'));
 
 const location = new URL('http://localhost');

--- a/packages/usdk/packages/upstreet-agent/packages/codecs/packages/mpg123-decoder/src/MPEGDecoder.fs.js
+++ b/packages/usdk/packages/upstreet-agent/packages/codecs/packages/mpg123-decoder/src/MPEGDecoder.fs.js
@@ -12,7 +12,7 @@ const loadWasm = p => {
   return m;
 };
 
-let dirname = getCurrentDirname(import.meta);
+let dirname = getCurrentDirname(import.meta, process);
 const wasmAudioDecoderCommon = loadWasm(path.join(dirname, '/wasm-audio-decoder-common.wasm'));
 const emscriptenWasm = loadWasm(path.join(dirname, '/emscripten-wasm.wasm'));
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/entry.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/entry.mjs
@@ -18,8 +18,8 @@ import path from 'path';
 //
 
 // this file should be running from the agent's directory, so we can find the wrangler.toml file relative to it
-const wranglerTomlPath = path.join(getCurrentDirname(import.meta), '../../../../wrangler.toml');
-const envTxtPath = path.join(getCurrentDirname(import.meta), '../../../../.env.txt');
+const wranglerTomlPath = path.join(getCurrentDirname(import.meta, process), '../../../../wrangler.toml');
+const envTxtPath = path.join(getCurrentDirname(import.meta, process), '../../../../.env.txt');
 
 //
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/node-runtime.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/node-runtime.mjs
@@ -5,7 +5,7 @@ import { getCurrentDirname} from '../react-agents/util/path-util.mjs'
 
 //
 
-const localDirectory = getCurrentDirname(import.meta);
+const localDirectory = getCurrentDirname(import.meta, process);
 
 //
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/watcher.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/watcher.mjs
@@ -7,7 +7,7 @@ import { getCurrentDirname } from '../react-agents/util/path-util.mjs';
 
 //
 
-const dirname = getCurrentDirname(import.meta);
+const dirname = getCurrentDirname(import.meta, process);
 
 const bindProcess = (cp) => {
   process.on('exit', () => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/path-util.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/path-util.mjs
@@ -1,9 +1,14 @@
 import path from 'path';
 
-export const getCurrentDirname = (importMeta) => {
+export const getCurrentDirname = (importMeta, _process = process) => {
   if (importMeta.dirname) {
     return importMeta.dirname;
-  } else {
+  } else if (importMeta.url) {
     return path.dirname(new URL(importMeta.url).pathname);
+  } else if (_process) { // In some environments, importMeta is not defined. So we revert to process.
+    return _process.cwd() 
+  } else { // We default to this, and pray to God it works.
+    console.info("[getCurrentDirname] Defaulting to '.'.")
+    return "."
   }
 };


### PR DESCRIPTION
## Why?
I needed to generate the command reference automatically from `usdk/cli.js`. But I was getting wasm import errors due to path.

So to resolve this, I have created this PR.

## What?
This PR is a more focused variant of #656 .
It only edits the `usdk`-related files, so that the team can easily review.

- Adds an edge case in `getCurrentDirname` which falls back to use `process.cwd()` if `import.meta` doesn't work.
- Updates all instances of `getCurrentDirname` to also pass `process`