### PR TITLE
feat: separate program creation from invocation

### DIFF
--- a/packages/usdk/cli.js
+++ b/packages/usdk/cli.js
@@ -1255,7 +1255,8 @@ const handleError = async (fn) => {
     process.exit(1);
   }
 };
-export const main = async () => {
+
+export const createProgram = () => {
   try {
 
     const ver = version();
@@ -1988,8 +1989,17 @@ export const main = async () => {
           await withdraw(args);
         });
       });*/
-    await program.parseAsync();
   } catch (error) {
-    console.error(error);
+    console.error("Error creating program:", error);
   }
+  return program
+};
+
+export const main = async () => {
+    createProgram();
+    try {
+      await program.parseAsync();
+    } catch (error) {
+      console.error("Error running program:", error);
+    }
 };


### PR DESCRIPTION
## Why?
I needed to generate the command reference automatically from `usdk/cli.js`. But every time I import and run `main`, it also runs `usdk`. I want to retrieve just the `program` separately, so I can mess with it.

So to resolve this, I have created this PR.

## What?
This PR is a more focused variant of #656 .
It only edits the `usdk`-related files, so that the team can easily review.

- Separate `createProgram` from `main`
- Adds try-catch on each step to ensure we know if something is broken