### PR TITLE
Import agent docs

### DIFF
--- a/apps/docs/content/docs/(getting-started)/create-an-agent.mdx
+++ b/apps/docs/content/docs/(getting-started)/create-an-agent.mdx
@@ -19,12 +19,12 @@ import pkgJson from 'usdk/package.json';
   </Accordion>
 </Accordions>
 
-Upstreet AI Agents are fully customizable digital entities that autonomously handle tasks, communicate, and interact according to your configuration.
+Upstreet AI Agents are persistent digital entities that can autonomously handle tasks, interact with you and your users over chat or social media, and can be customized according to your configuration.
 
 **New to designing Agents?** Explore how to define effective Agent objectives and strategies in our [Agent Design Concepts](/concepts/defining-agent-objectives).
 
 ## Quickstart: Creating an Agent
-With Upstreet, getting started is easy. Here’s how to set up your first Agent.
+Here’s how to set up your first Agent.
 
 ### Step 1: Running the command
 
@@ -53,9 +53,14 @@ The `usdk create` command initiates an interactive “interview” process with 
    Once all required fields are captured, the interview concludes, setting up all the Agent features and initialising the necessary files in your directory.
 
 <Callout>
-Want to **skip the interview** and jump right in the action? You can use the `-y` flag to skip the Agent Interview process.
+Want to **skip the interview** and jump right in with coding your agent?
+You can use the `-p` flag to pass a single creation prompt, or the `-y` to skip the interview process and create a default agent.
 You can also omit the agent directory. In that case, a directory will be created for you.
 </Callout>
+
+To import your agent from other platforms, `usdk create` also supports [Tavern character cards](https://github.com/malfoyslastname/character-card-spec-v2) and more.
+
+See [Importing an Agent](/import-an-agent) for more information.
 
 ### File Structure
 

--- a/apps/docs/content/docs/(getting-started)/import-an-agent.mdx
+++ b/apps/docs/content/docs/(getting-started)/import-an-agent.mdx
@@ -1,0 +1,28 @@
+---
+title: Import an Agent
+description: Import an agent from other platforms to use in USDK.
+full: false
+---
+ 
+import Wrapper from '../../../components/preview/wrapper';
+import { File, Folder, Files } from 'fumadocs-ui/components/files';
+ 
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { formatNodeVersion } from '../../../lib/utils';
+ 
+## Tavern Character Card
+
+You can import an agent from a Tavern Character Card using the `-i` or `--input` flag with `usdk create`:
+
+```bash
+usdk create -i ./character-card.png
+```
+
+This will skip the interview process and import the character's:
+- Name
+- Personality traits
+- Description and background
+- Profile picture
+- Other metadata like scenario and example conversations
+
+The SDK will automatically configure these attributes.

--- a/apps/docs/content/docs/(getting-started)/meta.json
+++ b/apps/docs/content/docs/(getting-started)/meta.json
@@ -1,5 +1,5 @@
 {
     "title": "Getting Started",
-    "pages": ["install", "create-an-agent", "customize-your-agent", "test-your-agent", "deploy-your-agent"],
+    "pages": ["install", "create-an-agent", "import-an-agent", "customize-your-agent", "test-your-agent", "deploy-your-agent"],
     "defaultOpen": true
 }


### PR DESCRIPTION
Adds docs for importing agents from Tavern Character Cards: https://github.com/malfoyslastname/character-card-spec-v2