### PR TITLE
Add missing playersMap player addition in playerSpec update

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs
@@ -186,6 +186,7 @@ export class ReactAgentsMultiplayerConnection extends EventTarget {
           if (key === 'playerSpec') {
             remotePlayer.setPlayerSpec(val);
             if (!playersMap.has(playerId)) {
+              playersMap.add(playerId, remotePlayer);
               // dispatch join event when the playerSpec is updated and the player is not already in the playersMap
               this.dispatchEvent(new MessageEvent('playerSpecUpdate', {
                 data: {


### PR DESCRIPTION
This PR fixes the following issue:
https://github.com/orgs/UpstreetAI/projects/7/views/1?pane=issue&itemId=88644610&issue=UpstreetAI%7Cupstreet-core%7C677

- case where the join event was fired before the remotePlayer's playerSpec was set leads to player not being in the playersMap
https://github.com/UpstreetAI/upstreet-core/blob/0272276f25154a7d997e094002aacbb946f64a0b/packages/usdk/packages/upstreet-agent/packages/react-agents-client/react-agents-client.mjs#L179

hence need to add the player to the playersMap when when 'update' event with 'playerSpec' key is fired and the playersId is not in the playersMap