### PR TITLE
Init args support

### DIFF
--- a/packages/usdk/lib/chat.mjs
+++ b/packages/usdk/lib/chat.mjs
@@ -19,6 +19,7 @@ export const chat = async (args, opts) => {
   const runtime = args.runtime ?? 'node';
   const inputStream = args.inputStream;
   const outputStream = args.outputStream;
+  const init = args.init ?? {};
   const debug = !!args.debug;
   // opts
   const jwt = opts.jwt;
@@ -42,6 +43,7 @@ export const chat = async (args, opts) => {
     if (agentSpec.directory) {
       const runtime = new Runtime(agentSpec);
       await runtime.start({
+        init,
         debug,
       });
       return runtime;

--- a/packages/usdk/lib/run-agent.mjs
+++ b/packages/usdk/lib/run-agent.mjs
@@ -7,6 +7,7 @@ import { parseAgentSpecs } from './agent-spec-utils.mjs';
 export const runAgent = async (args, opts) => {
   const agentSpecs = await parseAgentSpecs(args._[0]);
   const runtime = args.runtime ?? 'node';
+  const init = args.init ?? {};
   const debug = !!args.debug;
   // opts
   const jwt = opts.jwt;
@@ -34,6 +35,7 @@ export const runAgent = async (args, opts) => {
       const runtime = new Runtime(agentSpec);
       runtimes.push(runtime);
       await runtime.start({
+        init,
         debug,
       });
       console.log(`Agent ${agentSpec.guid} running on URL: http://localhost:${devServerPort + agentSpec.portIndex}`);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-main.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-main.mjs
@@ -231,6 +231,7 @@ const main = async () => {
     .option('--var <vars...>', 'Environment variables in format KEY:VALUE')
     .requiredOption('--ip <ip>', 'IP address to bind to')
     .requiredOption('--port <port>', 'Port to bind to')
+    .requiredOption('--init <json>', 'Initialization data')
     .action(async (directory, opts) => {
       commandExecuted = true;
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-runtime.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-runtime.mjs
@@ -86,6 +86,7 @@ export class ReactAgentsElectronRuntime {
     this.agentSpec = agentSpec;
   }
   async start({
+    init = {},
     debug = false,
   } = {}) {
     const {
@@ -102,6 +103,7 @@ export class ReactAgentsElectronRuntime {
         '--var', 'WORKER_ENV:development',
         '--ip', '0.0.0.0',
         '--port', devServerPort + portIndex,
+        '--init', JSON.stringify(init),
       ],
       {
         stdio: 'pipe',

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/entry.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/entry.mjs
@@ -63,7 +63,9 @@ const getAuth = async () => {
 
 //
 
-const main = async () => {
+const main = async ({
+  init = {},
+} = {}) => {
   const [
     env,
     auth,
@@ -76,6 +78,7 @@ const main = async () => {
   const state = {
     userRender,
     codecs,
+    init,
     storage: {
       async getAlarm() {
         return alarmTimestamp;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/node-runtime.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/node-runtime.mjs
@@ -31,6 +31,7 @@ export class ReactAgentsNodeRuntime {
     this.agentSpec = agentSpec;
   }
   async start({
+    init = {},
   } = {}) {
     const {
       directory,
@@ -51,6 +52,7 @@ export class ReactAgentsNodeRuntime {
         '--var', 'WORKER_ENV:development',
         '--ip', '0.0.0.0',
         '--port', devServerPort + portIndex,
+        '--init', JSON.stringify(init),
       ],
       {
         stdio: ['pipe', 'pipe', 'pipe', 'ipc'],

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/watcher.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/watcher.mjs
@@ -64,6 +64,9 @@ const reloadAgentWorker = async (directory, opts) => {
       if (opts.port) {
         args.push('--port', opts.port);
       }
+      if (opts.init) {
+        args.push('--init', opts.init);
+      }
 
       // create the worker
       let live = true;
@@ -190,6 +193,7 @@ const main = async () => {
     .option('--var <vars...>', 'Environment variables in format KEY:VALUE')
     .requiredOption('--ip <ip>', 'IP address to bind to')
     .requiredOption('--port <port>', 'Port to bind to')
+    .requiredOption('--init <init>', 'Initialization data')
     .action(async (directory, opts) => {
       commandExecuted = true;
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/worker.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/worker.mjs
@@ -57,16 +57,21 @@ const startAgentMainServer = async ({
   // console.log(`Agent server listening on http://${ip}:${port}`);
 };
 const runAgent = async (directory, opts) => {
-  const p = '/packages/upstreet-agent/packages/react-agents-node/entry.mjs';
-  const main = await loadModule(directory, p);
-  // console.log('worker loaded module', main);
-  const agentMain = await main();
-  // console.log('agentMain', agentMain);
-
   const {
     ip,
     port,
+    init: initString,
   } = opts;
+  const init = initString && JSON.parse(initString);
+
+  const p = '/packages/upstreet-agent/packages/react-agents-node/entry.mjs';
+  const main = await loadModule(directory, p);
+  // console.log('worker loaded module', main);
+  const agentMain = await main({
+    init,
+  });
+  // console.log('agentMain', agentMain);
+
   await startAgentMainServer({
     agentMain,
     ip,
@@ -108,6 +113,7 @@ const main = async () => {
     .option('--var <vars...>', 'Environment variables in format KEY:VALUE')
     .requiredOption('--ip <ip>', 'IP address to bind to')
     .requiredOption('--port <port>', 'Port to bind to')
+    .requiredOption('--init <json>', 'Initialization data')
     .action(async (directory, opts) => {
       commandExecuted = true;
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-wrangler/wrangler-runtime.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-wrangler/wrangler-runtime.mjs
@@ -88,6 +88,7 @@ export class ReactAgentsWranglerRuntime {
     this.agentSpec = agentSpec;
   }
   async start({
+    init = {},
     debug = false,
   } = {}) {
     const {
@@ -103,6 +104,7 @@ export class ReactAgentsWranglerRuntime {
         '--var', 'WORKER_ENV:development',
         '--ip', '0.0.0.0',
         '--port', devServerPort + portIndex,
+        '--init', JSON.stringify(init),
       ],
       {
         stdio: 'pipe',

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/agent-renderer.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/agent-renderer.tsx
@@ -136,6 +136,7 @@ export class AgentRenderer {
   userRender: UserHandler;
   chatsSpecification: ChatsSpecification;
   codecs: any;
+  init: any;
 
   registry: RenderRegistry;
   conversationManager: ConversationManager;
@@ -155,12 +156,14 @@ export class AgentRenderer {
     userRender,
     chatsSpecification,
     codecs,
+    init,
   }: {
     env: any;
     auth: any;
     userRender: UserHandler;
     chatsSpecification: ChatsSpecification;
     codecs: any;
+    init: any;
   }) {
     // latch arguments
     this.env = env;
@@ -168,6 +171,7 @@ export class AgentRenderer {
     this.userRender = userRender;
     this.chatsSpecification = chatsSpecification;
     this.codecs = codecs;
+    this.init = init;
 
     // create the app context
     this.registry = new RenderRegistry();
@@ -208,6 +212,9 @@ export class AgentRenderer {
     const useCodecs = () => {
       return this.codecs;
     };
+    const useInit = () => {
+      return this.init;
+    };
     const useRegistry = () => {
       return this.registry;
     };
@@ -222,6 +229,7 @@ export class AgentRenderer {
       conversationManager: useConversationManager(),
       chatsSpecification: useChatsSpecification(),
       codecs: useCodecs(),
+      init: useInit(),
       registry: useRegistry(),
     });
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/app-context-value.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/app-context-value.ts
@@ -37,6 +37,7 @@ export class AppContextValue {
   conversationManager: ConversationManager;
   chatsSpecification: ChatsSpecification;
   codecs: any;
+  init: any;
   registry: RenderRegistry;
 
   constructor({
@@ -50,6 +51,7 @@ export class AppContextValue {
     conversationManager,
     chatsSpecification,
     codecs,
+    init,
     registry,
   }: {
     subtleAi: SubtleAi;
@@ -62,6 +64,7 @@ export class AppContextValue {
     conversationManager: ConversationManager;
     chatsSpecification: ChatsSpecification;
     codecs: any;
+    init: any;
     registry: RenderRegistry;
   }) {
     this.subtleAi = subtleAi;
@@ -74,6 +77,7 @@ export class AppContextValue {
     this.conversationManager = conversationManager;
     this.chatsSpecification = chatsSpecification;
     this.codecs = codecs;
+    this.init = init;
     this.registry = registry;
   }
 
@@ -105,6 +109,9 @@ export class AppContextValue {
   }
   useCodecs() {
     return this.codecs;
+  }
+  useInit() {
+    return this.init;
   }
   useRegistry() {
     return this.registry;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/entry.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/entry.ts
@@ -45,12 +45,14 @@ export class AgentMain extends EventTarget {
     const {
       userRender,
       codecs,
+      init,
     } = state;
     this.agentRenderer = new AgentRenderer({
       env,
       auth,
       userRender,
       codecs,
+      init,
       chatsSpecification: this.chatsSpecification,
     });
     const bindAlarm = () => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/hooks.ts
@@ -63,6 +63,11 @@ export const useAuthToken: () => string = () => {
   const appContextValue = useContext(AppContext);
   return appContextValue.useAuthToken();
 };
+// get the passed-down agent initialization json
+export const useInit: () => any = () => {
+  const appContextValue = useContext(AppContext);
+  return appContextValue.useInit();
+};
 
 //
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
@@ -147,6 +147,7 @@ export type TwitterSpacesArgs = {
   url?: string;
   agent: ActiveAgentObject;
   codecs: any;
+  init: any;
   jwt: string;
 };
 
@@ -778,6 +779,7 @@ export type AppContextValue = {
   useConversationManager: () => ConversationManager;
   useChatsSpecification: () => ChatsSpecification;
   useCodecs: () => any;
+  useInit: () => any;
   useRegistry: () => RenderRegistry;
 
   useKv: (opts?: KvArgs) => Kv;


### PR DESCRIPTION
Pass down `init` argument to agent runtime, with hooks to access it. This allows optional initialization to be passed down on a per-agent basis, which is very useful for development.