### PR TITLE
fix(dm): Prevent creating duplicate conversations for users in multiple common servers/on reconnection

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -260,6 +260,13 @@ export class DiscordBot extends EventTarget {
           id: userId,
         } = user;
 
+        // Check if dm conversation already exists for this user.
+        // This occurs when the same user exists in multiple common servers.
+        if (this.dmConversations.has(userId)) {
+          console.log('dm conversation already exists for this user, skipping', userId);
+          return
+        }
+        
         const conversation = new ConversationObject({
           agent,
           getHash: () => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -221,6 +221,13 @@ export class DiscordBot extends EventTarget {
           type === 2 || // voice channel
           type === 13 // stage
         ) {
+          // Check if channel conversation already exists.
+          // XXX: This would occur during a hot reload 
+          if (this.channelConversations.has(channelId)) {
+            console.log('channel conversation already exists, skipping', channelId);
+            return
+          }
+
           const conversation = new ConversationObject({
             agent,
             getHash: () => {


### PR DESCRIPTION
Add guard to dm conversation creation (users having common servers, dm event for each guild)


Fixes:
https://github.com/UpstreetAI/upstreet-core/issues/689


- Discord Agent Bot goes through each member in guild and sends 'dmconnect' event to the connected user
- connected user on receiving the 'dmconnect' creates a new conversation object, uses the discord user's userId as hash and adds it to the manager

- so here since the userId is being used to create the conversation object key
- a user with common servers with the bot will be sent twice with dmconnect (from each guild/server)
- since this is dm, there must be no duplicate dm conversations for the same user