### PR TITLE
Add missing SIGTERM listeners

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-main.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-main.mjs
@@ -17,6 +17,9 @@ console.log('electron start script!');
     console.warn(err.stack);
   });
 });
+process.addListener('SIGTERM', () => {
+  process.exit(0);
+});
 
 // electron doesn't provide a native WebSocket
 // this is needed for needed for the multiplayer library

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-runtime.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-runtime.mjs
@@ -4,6 +4,9 @@ import { electronBinPath, electronStartScriptPath } from './util/locations.mjs';
 
 //
 
+process.addListener('SIGTERM', () => {
+  process.exit(0);
+});
 const bindProcess = (cp) => {
   process.on('exit', () => {
     // console.log('got exit', cp.pid);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/node-runtime.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/node-runtime.mjs
@@ -9,9 +9,11 @@ const localDirectory = getCurrentDirname(import.meta, process);
 
 //
 
+process.addListener('SIGTERM', () => {
+  process.exit(0);
+});
 const bindProcess = (cp) => {
   process.on('exit', () => {
-    // console.log('got exit', cp.pid);
     try {
       process.kill(cp.pid, 'SIGTERM');
     } catch (err) {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/watcher.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/watcher.mjs
@@ -9,9 +9,13 @@ import { getCurrentDirname } from '../react-agents/util/path-util.mjs';
 
 const dirname = getCurrentDirname(import.meta, process);
 
+// watch SIGTERM
+process.on('SIGTERM', () => {
+  process.exit(0);
+});
+
 const bindProcess = (cp) => {
   process.on('exit', () => {
-    // console.log('got exit', cp.pid);
     try {
       process.kill(cp.pid, 'SIGTERM');
     } catch (err) {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/worker.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/worker.mjs
@@ -16,6 +16,10 @@ import { serve } from '@hono/node-server';
   });
 });
 
+process.addListener('SIGTERM', () => {
+  process.exit(0);
+});
+
 //
 
 const homeDir = os.homedir();

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-wrangler/wrangler-runtime.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-wrangler/wrangler-runtime.mjs
@@ -4,6 +4,9 @@ import { devServerPort } from './util/ports.mjs';
 
 //
 
+process.addListener('SIGTERM', () => {
+  process.exit(0);
+});
 const bindProcess = (cp) => {
   process.on('exit', () => {
     // console.log('got exit', cp.pid);


### PR DESCRIPTION
The runtime processes weren't properly feeding sigterm down to the children, leaving dangling runtimes.

Add

```
process.addListener('SIGTERM', () => {
```

to each.