### PR TITLE
Sync discord bot to agent details

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -46,6 +46,8 @@ const testRoomNameMatch = (channelName: string, channelSpec: DiscordRoomSpec) =>
     return false;
   }
 };
+
+// bind sending messages from agent -> discord
 const bindOutgoing = ({
   conversation,
   discordBotClient,
@@ -206,6 +208,8 @@ export class DiscordBot extends EventTarget {
       console.log('discord connect 4');
       if (signal.aborted) return;
       console.log('discord connect 5');
+
+      discordBotClient.initSyncBotAndAgentData();
     };
     const _bindChannels = () => {
       discordBotClient.addEventListener('channelconnect', (e: MessageEvent<{channel: any}>) => {
@@ -368,12 +372,25 @@ export class DiscordBot extends EventTarget {
         }
       });
     };
+    const _bindProfileData = () => {
+      discordBotClient.addEventListener('profileData', (e: MessageEvent) => {
+        const {
+          username,
+          avatarUrl,
+        } = e.data;
+        discordBotClient.syncBotProfileWithAgent(this.agent, {
+          username,
+          avatarUrl,
+        });
+      });
+    };
 
     (async () => {
       _bindChannels();
       _bindGuildMemberAdd();
       _bindGuildMemberRemove();
       _bindIncoming();
+      _bindProfileData();
       await _connect();
     })().catch(err => {
       console.warn('discord bot error', err);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
@@ -550,10 +550,10 @@ export class DiscordBotClient extends EventTarget {
       console.log('update username', name);
       this.updateUsername(name);
     }
-    if (previewUrl && previewUrl !== avatarUrl) {
-      console.log('update avatar', previewUrl);
-      this.updateAvatar(previewUrl);
-    }
+    // if (previewUrl && previewUrl !== avatarUrl) {
+    //   console.log('update avatar', previewUrl);
+    //   this.updateAvatar(previewUrl);
+    // }
   }
 
   destroy() {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
@@ -175,6 +175,16 @@ export class DiscordInput {
     this.ws.send(s);
   }
 
+  getBotProfile() {
+    const m = {
+      method: 'profileData',
+      args: {},
+    };
+    const s = JSON.stringify(m);
+    this.ws.send(s);
+  }
+
+
   destroy() {
     // nothing
   }
@@ -428,6 +438,12 @@ export class DiscordBotClient extends EventTarget {
           args,
         } = j;
         switch (method) {
+          case 'profileData': {
+            this.dispatchEvent(new MessageEvent('profileData', {
+              data: args,
+            }));
+            break;
+          }
           case 'ready': {
             readyPromise.resolve();
             break;
@@ -492,6 +508,52 @@ export class DiscordBotClient extends EventTarget {
 
     await connectPromise;
     await readyPromise;
+  }
+
+  updateUsername(name) {
+    const m = {
+      method: 'setUsername',
+      args: {
+        name,
+      },
+    };
+    const s = JSON.stringify(m);
+    this.ws.send(s);
+  }
+
+  updateAvatar(avatarUrl) {
+    console.log('update avatar', avatarUrl);
+  }
+  initSyncBotAndAgentData() {
+    this.input.getBotProfile();
+  }
+
+  syncBotProfileWithAgent(agent, botProfile) {
+    const {
+      name,
+      previewUrl,
+    } = agent;
+
+    const {
+      username,
+      avatarUrl,
+    } = botProfile;
+    
+    console.log('syncBotProfileWithAgent', {
+      name,
+      username,
+      previewUrl,
+      avatarUrl,
+    });
+
+    if (name && name !== username) {
+      console.log('update username', name);
+      this.updateUsername(name);
+    }
+    if (previewUrl && previewUrl !== avatarUrl) {
+      console.log('update avatar', previewUrl);
+      this.updateAvatar(previewUrl);
+    }
   }
 
   destroy() {


### PR DESCRIPTION
This PR updates currently the Agent name and Discord bot username.

- adds 'profileData' to DiscordInput class to get discord bot client data
- discord client data is fetched everytime a connection is established
- if the discord client data and agent name have a mismatch, setUsername event is sent to the server side for updating the discord client name to use the set Agent name

setAvatar is not being updated currently