### PR TITLE
Turbopack dev servers

### DIFF
--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Web-based chat application for Upstreet",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "start": "next start",
     "postinstall": "fumadocs-mdx"
   },


### PR DESCRIPTION
Adds [Turbopack](https://nextjs.org/docs/architecture/turbopack) support to our dev server startup commands (this only works in dev). Turbopack is currently still experimental.

The main reason to switch is to fix the annoying issue that causes the the first load of the dev server to crash. We aren't the only ones running into this issue:

https://stackoverflow.com/questions/77788615/next-js-uncaught-syntaxerror-invalid-or-unexpected-token-then-chunkloaderror

Note that the answer says you need to remove your `.next` for this fix to be effective.