### PR TITLE
Add node_modules to ignore function while recursiveReaddir

### DIFF
--- a/packages/usdk/lib/zip-util.mjs
+++ b/packages/usdk/lib/zip-util.mjs
@@ -35,13 +35,8 @@ export const packZip = async (dirPath, { exclude = [] } = {}) => {
       resolve(uary);
     });
 
-    // use ignore function with recursive-readdir to filter out node_modules
-    const ignoreFunc = (file, stats) => {
-      // ignore node_modules directories
-      if (stats.isDirectory() && file.includes('node_modules')) {
-        return true;
-      }
-      // apply other exclude patterns
+    // use ignore function with recursive-readdir to filter out excluded patterns
+    const ignoreFunc = (file) => {
       return exclude.some(pattern => pattern.test(file));
     };
     

--- a/packages/usdk/lib/zip-util.mjs
+++ b/packages/usdk/lib/zip-util.mjs
@@ -35,8 +35,17 @@ export const packZip = async (dirPath, { exclude = [] } = {}) => {
       resolve(uary);
     });
 
-    // Filter files and add to archive
-    recursiveReaddir(dirPath)
+    // use ignore function with recursive-readdir to filter out node_modules
+    const ignoreFunc = (file, stats) => {
+      // ignore node_modules directories
+      if (stats.isDirectory() && file.includes('node_modules')) {
+        return true;
+      }
+      // apply other exclude patterns
+      return exclude.some(pattern => pattern.test(file));
+    };
+    
+    recursiveReaddir(dirPath, [ignoreFunc])
       .then((files) => {
         const filteredFiles = filterFiles(files, exclude);
 


### PR DESCRIPTION
Issue:
- ENAMETOOLONG

![image](https://github.com/user-attachments/assets/b33ae0cc-1523-40dc-815b-42cda1016d94)

Solution:
- Add ignore function to the recursiveReaddir function call to ignore all files with node_modules