### PR TITLE
Specific conversation object argument based filtering for handling Chat Perception 

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
@@ -344,10 +344,17 @@ export const collectPriorityModifiers = <T extends PriorityModifier>(modifiers: 
     .sort((aEntry, bEntry) => aEntry[0] - bEntry[0])
     // .map((entry) => entry[1]);
 };
-export const filterModifiersPerConversation = <T extends PriorityModifier>(modifiers: Array<[number, T[]]>, conversation: ConversationObject) => {
+export const filterModifiersPerConversation = <T extends PriorityModifier>(
+  modifiers: Array<[number, T[]]>, 
+  conversation: ConversationObject | null
+) => {
   return modifiers.map(([priority, modifiersArray]) => [
     priority,
-    modifiersArray.filter((modifier) => !modifier.conversation || modifier.conversation === conversation),
+    modifiersArray.filter(modifier => 
+      conversation ? 
+        modifier.conversation === conversation : 
+        !modifier.conversation
+    ),
   ]) as Array<[number, T[]]>;
 };
 export const filterModifiersPerType = <T extends PriorityModifier>(modifiers: Array<[number, T[]]>, name: string) => {


### PR DESCRIPTION
Issue:

- Chat perception being evaluated twice, once with null conversation and once with the relevant conversation
- handle null conversation more explicitly to avoid multiple reasons in a chat conversation