### PR TITLE
Pass mouse events through transparent elements

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-main.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/electron-main.mjs
@@ -9,10 +9,12 @@ import { WebSocket } from 'ws';
 import * as debugLevels from '../react-agents/util/debug-levels.mjs';
 import { Button, Key, keyboard, mouse, Point } from '@nut-tree-fork/nut-js';
 import { fileURLToPath } from 'url';
-
+import { updateIgnoreMouseEvents } from './lib/updateIgnoreMouseEvents.js';
 //
 
 console.log('electron start script!');
+
+const UPDATE_INTERVAL = 1000 / 60;
 
 ['uncaughtException', 'unhandledRejection'].forEach(event => {
   process.on(event, err => {
@@ -234,7 +236,6 @@ const openFrontend = async ({
       transparent: true,
       backgroundColor: '#00000000',
       frame: false,
-      hasShadow: false,
       alwaysOnTop: true,
       resizable: false,
       titleBarStyle: 'none',
@@ -246,6 +247,10 @@ const openFrontend = async ({
         contextIsolation: true,
         enableRemoteModule: false,
       },
+
+      // macOS
+      acceptFirstMouse: true,
+      hasShadow: false,
     });
     if (debug >= debugLevels.SILLY) {
       win.webContents.openDevTools();
@@ -257,6 +262,11 @@ const openFrontend = async ({
       name: 'auth-jwt',
       value: jwt,
     });
+
+    setInterval(() => {
+      // Allow mouse events to pass through the window.
+      updateIgnoreMouseEvents( win )
+    }, UPDATE_INTERVAL )
 
     await win.loadURL(dstUrl.href);
   }

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/lib/updateIgnoreMouseEvents.js
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-electron/lib/updateIgnoreMouseEvents.js
@@ -1,0 +1,31 @@
+/**
+ * This allows mouse events to pass through transparent elements by
+ * checking the alpha value of the pixel at the mouse position and
+ * setting the ignoreMouseEvents property of the window accordingly.
+ */
+async function updateIgnoreMouseEvents( win ) {
+  const
+    point = screen.getCursorScreenPoint(),
+    [ x, y ] = win.getPosition(),
+    [ w, h ] = win.getSize()
+
+  // Ignore out-of-bounds events.
+  if (
+    point.x > x
+    && point.x < x + w
+    && point.y > y
+    && point.y < y + h
+  ) {
+
+    // Capture 1x1 image of mouse position.
+    const image = await win.webContents.capturePage({
+      x: point.x - x,
+      y: point.y - y,
+      width: 1,
+      height: 1,
+    })
+
+    // Set ignore mouse events according to alpha.
+    win.setIgnoreMouseEvents( !image.getBitmap()[3])
+  }
+}


### PR DESCRIPTION
Now the mouse properly passes through transparent elements, so that the UI can stop occluding my screen while working.