### PR TITLE
Mentions Support: Add Social client specifications to Active Agent Object

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/active-agent-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/active-agent-object.ts
@@ -56,6 +56,7 @@ export class ActiveAgentObject extends AgentObject {
   liveManager: LiveManager;
   pingManager: PingManager;
   generativeAgentsMap = new WeakMap<ConversationObject, GenerativeAgentObject>();
+  socialSpecs: object;
 
   //
   
@@ -116,6 +117,7 @@ export class ActiveAgentObject extends AgentObject {
       userId: this.id,
       supabase: this.useSupabase(),
     });
+    this.socialSpecs = {};
   }
 
   // static hooks
@@ -236,6 +238,15 @@ export class ActiveAgentObject extends AgentObject {
     } else {
       throw new Error(error2);
     }
+  }
+  updateSocialSpecs(socialSpecs: object) {
+    this.socialSpecs = {
+      ...this.socialSpecs,
+      ...socialSpecs,
+    };
+  }
+  getSocialSpecs() {
+    return this.socialSpecs;
   }
   live() {
     this.chatsManager.live();

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -152,6 +152,7 @@ export class DiscordBot extends EventTarget {
     this.abortController = new AbortController();
     const { signal } = this.abortController;
 
+    // add relevent discord information to the agent's social specs variable
     agent.updateSocialSpecs({
       discord: {
         userId: clientId,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -24,7 +24,7 @@ import {
 //
 
 const getIdFromUserId = (userId: string) => uuidByString(userId);
-const makePlayerFromMember = (member: any) => {
+const makePlayerFromDiscordMember = (member: any) => {
   const {
     userId,
     displayName,
@@ -34,6 +34,11 @@ const makePlayerFromMember = (member: any) => {
   const player = new Player(id, {
     name: displayName,
     previewUrl: displayAvatarURL,
+    socialSpecs: {
+      discord: {
+        userId,
+      },
+    },
   });
   return player;
 };
@@ -324,7 +329,7 @@ export class DiscordBot extends EventTarget {
         // console.log('got guild member add', {
         //   member,
         // });
-        const player = makePlayerFromMember(member);
+        const player = makePlayerFromDiscordMember(member);
         for (const conversation of this.channelConversations.values()) {
           conversation.addAgent(player.playerId, player);
         }

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -119,6 +119,7 @@ const bindOutgoing = ({
 
 export class DiscordBot extends EventTarget {
   token: string;
+  clientId: string;
   channels: DiscordRoomSpec[];
   dms: DiscordRoomSpec[];
   userWhitelist: string[];
@@ -132,6 +133,7 @@ export class DiscordBot extends EventTarget {
     // arguments
     const {
       token,
+      clientId,
       channels,
       dms,
       userWhitelist,
@@ -140,6 +142,7 @@ export class DiscordBot extends EventTarget {
       jwt,
     } = args;
     this.token = token;
+    this.clientId = clientId;
     this.channels = channels;
     this.dms = dms;
     this.userWhitelist = userWhitelist;
@@ -149,6 +152,12 @@ export class DiscordBot extends EventTarget {
     this.abortController = new AbortController();
     const { signal } = this.abortController;
 
+    agent.updateSocialSpecs({
+      discord: {
+        userId: clientId,
+      },
+    });
+    
     // initialize discord bot client
     const discordBotClient = new DiscordBotClient({
       token,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -11,6 +11,7 @@ import {
 export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
   const {
     token,
+    clientId,
     channels,
     dms,
     userWhitelist,
@@ -25,6 +26,7 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
     if (!conversation) {
       const args: DiscordArgs = {
         token,
+        clientId,
         channels: channels ? (Array.isArray(channels) ? channels : [channels]) : [],
         dms: dms ? (Array.isArray(dms) ? dms : [dms]) : [],
         userWhitelist,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
@@ -121,6 +121,7 @@ const CharactersPrompt = () => {
       id: agent.id,
       name,
       bio,
+      socialSpecs: agent.getSocialSpecs(),
     };
     const agentSpecs = agents.map((agent) => agent.getPlayerSpec());
 
@@ -129,6 +130,7 @@ const CharactersPrompt = () => {
         `Name: ${agent.name}`,
         `UserId: ${agent.id}`,
         `Bio: ${agent.bio}`,
+        `${agent.socialSpecs ? `Social Specifications: ${JSON.stringify(agent.socialSpecs, null, 2)}` : ''}`,
       ].join('\n');
     };
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/agents.d.ts
@@ -121,12 +121,14 @@ export type DiscordRoomSpec = RegExp | string;
 export type DiscordRoomSpecs = DiscordRoomSpec | DiscordRoomSpec[];
 export type DiscordProps = {
   token: string;
+  clientId: string;
   channels?: DiscordRoomSpecs;
   dms?: DiscordRoomSpecs;
   userWhitelist?: string[];
 };
 export type DiscordArgs = {
   token: string;
+  clientId: string;
   channels: DiscordRoomSpec[];
   dms: DiscordRoomSpec[];
   userWhitelist: string[];
@@ -457,6 +459,7 @@ export type ActiveAgentObject = AgentObject & {
   pingManager: PingManager;
   liveManager: LiveManager;
   generativeAgentsMap: WeakMap<ConversationObject, GenerativeAgentObject>;
+  socialSpecs: object;
 
   //
 
@@ -481,6 +484,8 @@ export type ActiveAgentObject = AgentObject & {
     text: string,
     content?: any,
   ) => Promise<Memory>;
+  updateSocialSpecs: (socialSpecs: object) => void;
+  getSocialSpecs: () => object;
 
   live: () => void;
   destroy: () => void;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features.mjs
@@ -145,11 +145,12 @@ export const featureSpecs = [
     schema: z.union([
       z.object({
         token: z.string(),
+        clientId: z.string(),
         channels: z.array(z.string()),
       }),
       z.null(),
     ]),
-    examples: [{ token: 'YOUR_DISCORD_BOT_TOKEN', channels: ['general', 'voice'], }],
+    examples: [{ token: 'YOUR_DISCORD_BOT_TOKEN', clientId: 'YOUR_DISCORD_CLIENT_ID', channels: ['general', 'voice'], }],
     imports: (discord) => {
       if (discord.token) {
         return ['Discord'];
@@ -164,6 +165,7 @@ export const featureSpecs = [
           dedent`
             <Discord
               token=${JSON.stringify(discord.token)}
+              clientId=${JSON.stringify(discord.clientId)}
               ${discord.channels ? `channels={${JSON.stringify(channels)}}` : ''}
             />
           `,


### PR DESCRIPTION
This PR adds the ability to add social specifications such as their userId, social name etc to the Agent.

Why this was required?
- For the Agent to be able to understand mentions on social platforms and for adding additional platform specific context to the Agent.
- Additional context is added to the final prompt via the CharactersPrompt based on the social integrations the Agent/Player has, currently in case of Discord bot the Agent should know and recognise their **discord bot userId** as well as other members present in the discord channel or a dm.

How its working?
- The Discord component now requires the bot's clientId as a required param, so that the Agent has their own discord bot id in context without any fetches.
- The Discord manager updates the Agent's socialSpecs var to contain any Discord related information (currently the Agent's bot id as their userId)
- Same process is for each of the member added into the conversation via Discord

Discord's mention format:
- @Subhani : @<113131231232113> 

Test:

To test if the agent is able to recognise user tags/mentions, i tried:

- In a test server, tagging different users in a message and asking the agent who was tagged to extract info.
- To the test above, the agent was fully able to understand which user was tagged in the certain message (due to the userId's being available in the Character Prompt)

![image](https://github.com/user-attachments/assets/2117e260-5af4-4149-8e06-2bdf5189e7d0)
