### PR TITLE
Agent Discord Message Referenced Reply

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -352,6 +352,7 @@ export class DiscordBot extends EventTarget {
           username,
           text,
           channelId, // if there is no channelId, it's a DM
+          messageId,
           // XXX discord channel/dm distinction can be made more explicit with a type: string field...
         } = e.data;
 
@@ -367,6 +368,7 @@ export class DiscordBot extends EventTarget {
             method: 'say',
             args: {
               text,
+              messageId,
             },
           };
           const id = getIdFromUserId(userId);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -20,6 +20,7 @@ import {
 import {
   QueueManager,
 } from 'queue-manager';
+import { SceneObject } from './scene-object';
 
 //
 
@@ -233,11 +234,17 @@ export class DiscordBot extends EventTarget {
             return
           }
 
+          const scene = new SceneObject({
+            name: 'Discord Channel Conversation',
+            description: 'A conversation happening in a Discord channel.',
+          });
+
           const conversation = new ConversationObject({
             agent,
             getHash: () => {
               return `discord:channel:${channelId}`;
             },
+            scene,
           });
 
           this.agent.conversationManager.addConversation(conversation);
@@ -279,11 +286,17 @@ export class DiscordBot extends EventTarget {
           return
         }
         
+        const scene = new SceneObject({
+          name: 'Discord Direct Message Conversation',
+          description: 'A conversation happening with a user on Discord.',
+        });
+        
         const conversation = new ConversationObject({
           agent,
           getHash: () => {
             return `discord:dm:${userId}`;
           },
+          scene,
         });
 
         this.agent.conversationManager.addConversation(conversation);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -1,12 +1,16 @@
+import React from 'react';
 import { useContext, useEffect } from 'react';
-import { useAgent, useAuthToken, useConversation } from 'react-agents';
+import { Action, ConversationProvider, useAgent, useAuthToken, useConversation } from 'react-agents';
 import type {
   DiscordArgs,
   DiscordProps,
+  PendingActionEvent,
 } from '../../types';
 import {
   AppContext,
 } from '../../context';
+import dedent from 'dedent';
+import { z } from 'zod';
 
 export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
   const {
@@ -45,5 +49,50 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
     conversation,
   ]);
 
-  return null;
+  return (
+    <>
+     <ConversationProvider>
+      <Action
+        type="discordMessageReply"
+        description={dedent`
+          Use this Action to reply to a specific message within a Discord channel or direct message (DM) when you feel it is necessary to respond according to the context of the message.
+          Additionally, use this Action in most cases where you are mentioned using '@' in order to respond back directly to that message.
+        `}
+        schema={
+          z.object({
+          messageReference: z.string(),
+          content: z.string(),
+          })
+        }
+        examples={[
+          {
+            messageReference: '1234567890',
+            content: 'Yea, I got it.',
+          },
+        ]}
+        handler={
+          async (e: PendingActionEvent) => {
+            const {
+              message,
+              agent,
+            } = e.data;
+
+            const {
+              messageReference,
+              content,
+            } = message.args;
+
+            const replyMessage = {
+              content: content,
+              reply: {
+                messageReference: messageReference,
+              }
+            }
+            await agent.say(replyMessage);
+          }
+        }
+      />
+     </ConversationProvider>
+    </>
+  );
 };

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -55,7 +55,7 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
       <Action
         type="discordMessageReply"
         description={dedent`
-          Use this Action to reply to a specific message within a Discord channel or direct message (DM) when you feel it is necessary to respond according to the context of the message.
+          Use this Action to reply to a specific message ONLY within a Discord channel or direct message (DM) when you feel it is necessary to respond according to the context of the message.
           Additionally, use this Action in most cases where you are mentioned using '@' in order to respond back directly to that message.
         `}
         schema={

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -53,21 +53,21 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
     <>
      <ConversationProvider>
       <Action
-        type="discordMessageReply"
+        type="discordMessageReferenceReply"
         description={dedent`
-          Use this Action to reply to a specific message ONLY within a Discord channel or direct message (DM) when you feel it is necessary to respond according to the context of the message.
-          Additionally, use this Action in most cases where you are mentioned using '@' in order to respond back directly to that message.
+          Use this Action to refer back to a specific message in the chat history or when replying to a message where you were specifically tagged using '@'.
+          Ensure the response is contextually relevant to the message being referenced or replied to.
         `}
         schema={
           z.object({
-          messageReference: z.string(),
-          content: z.string(),
+            messageReference: z.string(),
+            content: z.string(),
           })
         }
         examples={[
           {
             messageReference: '1234567890',
-            content: 'Yea, I got it.',
+            content: 'Yes, I understand your point.',
           },
         ]}
         handler={

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -56,7 +56,7 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
         type="discordMessageReferenceReply"
         description={dedent`
           Use this Action:
-          - STRICTLY WITHIN A DISCORD CHANNEL OR DIRECT MESSAGE (DM) SCENE
+          - STRICTLY WITHIN A DISCORD CHANNEL OR DIRECT MESSAGE (DM) SCENE, IF NO SCENE IS PROVIDED OR THE SCENE IS NOT A DISCORD CHANNEL OR DIRECT MESSAGE (DM), THE ACTION MUST NOT BE EXECUTED.
           - To refer back to a specific message in the chat history or when replying to a message where you were specifically tagged using '@<your-discord-id>'.
           
           Ensure the response is contextually relevant to the message being referenced or replied to.

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -55,7 +55,10 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
       <Action
         type="discordMessageReferenceReply"
         description={dedent`
-          Use this Action to refer back to a specific message in the chat history or when replying to a message where you were specifically tagged using '@'.
+          Use this Action:
+          - STRICTLY WITHIN A DISCORD CHANNEL OR DIRECT MESSAGE (DM) SCENE
+          - To refer back to a specific message in the chat history or when replying to a message where you were specifically tagged using '@<your-discord-id>'.
+          
           Ensure the response is contextually relevant to the message being referenced or replied to.
         `}
         schema={


### PR DESCRIPTION
This PR depends on for ensuring message id for discord messages are added to context:
https://github.com/UpstreetAI/upstreet/pull/1445

Implementation:

- Add SceneObject to the Conversation to provide Agent with the conversation environment context (Discord Channel + Discord DM)
- Extract Message ID and add the id to the local message
- Add a Discord Component Action, "discordMessageReferenceReply" to be used when the Agent thinks it should reply back to the user with a specific message reference.
- "discordMessageReferenceReply" is described to be strictly used within the Discord Channel/DM Scene environment to ensure the action would not be opted for in environments where either no Scene is provided or the Scene is not a Discord Environment
- The action formats the "say" message specifically to the discord's message.reply structure, .send() function can take formatted inputs as current used in for "reply"/"embed" message etc.
format:
```
for replies:
{
  content: "message",
  reply: {
    messageReference
  } 
}

for embeds:
{
  content: "message",
  embeds: [{...}],
}
```

Tested Implementation with Syborg in the "bot-playground -> syborg" channel

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/bd7c75ab-e57b-45c5-a9b8-63e8e7ffe3c0" />
