### PR TITLE
add missing jest dep to upstreet-agent

### DIFF
--- a/packages/usdk/packages/upstreet-agent/package.json
+++ b/packages/usdk/packages/upstreet-agent/package.json
@@ -16,6 +16,7 @@
     "ethers": "^6.12.0",
     "format-util": "^1.0.5",
     "javascript-time-ago": "^2.5.11",
+    "jest": "^29.0.0",
     "jimp": "^1.6.0",
     "memoize-one": "^6.0.0",
     "minimatch": "^9.0.4",


### PR DESCRIPTION
Fix for:

- add jest dep to upstreet-agent package.json

<img width="583" alt="image" src="https://github.com/user-attachments/assets/c3e675d9-1f91-4d68-9c18-47e7585455e4" />

