### PR TITLE
Generate and Add numeric suffix to the default AI Agent name

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-json-util.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-json-util.mjs
@@ -17,7 +17,8 @@ export const ensureAgentJsonDefaults = (spec) => {
   };
 
   if (typeof spec.name !== 'string') {
-    spec.name = 'AI Agent';
+    const suffix = Math.floor(10000 + Math.random() * 90000);
+    spec.name = `AI Agent #${suffix}`;
   }
   if (typeof spec.description !== 'string') {
     spec.description = 'Created by the AI Agent SDK';


### PR DESCRIPTION
Generate a random number between:
- min 10000 
- max 99999
- Add to the default name spec