### PR TITLE
Abstracted Chat Message User Mentions support

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -183,14 +183,14 @@ export class ConversationObject extends EventTarget {
   }
 
   // format message for prompt
-  formatMessage(message: ActionMessage) {
+  formatMessage(message: string) {
     const mentions = this.getMessageMentions(message);
     if (mentions) {
       mentions.forEach(mentionId => {
         for (const [userId, player] of this.agentsMap.entries()) {
           const playerSpec = player.getPlayerSpec();
-          if (playerSpec && playerSpec.discordId === mentionId) {
-            message.args.text = message.args.text.replace(new RegExp(`<@${mentionId}>`, 'g'), `@${userId}`);
+          if (playerSpec && playerSpec.mentionId === mentionId) {
+            message = message.replace(new RegExp(`<@${mentionId}>`, 'g'), `@${userId}`);
             break;
           }
         }
@@ -199,15 +199,17 @@ export class ConversationObject extends EventTarget {
     return message;
   }
 
-  getMessageMentions(message: ActionMessage) {
+  getMessageMentions(message: string) {
     if (!this.mentionsRegex) {
       return null;
     }
-    const matches = message.args.text.match(this.mentionsRegex);
-    return matches?.map(m => {
-      const match = m.match(this.mentionsRegex);
-      return match?.groups?.id || null;
-    }).filter(Boolean); // filter out any null values
+    const matches = message.match(this.mentionsRegex);
+    if (!matches) return null;
+    
+    // extract just the ID numbers from <@ID> format
+    return matches.map(mention => 
+      mention.replace(/[<@>]/g, '')
+      ).filter(Boolean);
   }
   /* async fetchMessages(filter: MessageFilter, {
     supabase,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -23,7 +23,7 @@ import {
 
 //
 
-const discordMentionRegex = /@<(?<id>\d+)>/g;
+const discordMentionRegex = /<@(?<id>\d+)>/g;
 const getIdFromUserId = (userId: string) => uuidByString(userId);
 const makePlayerFromMember = (member: any) => {
   const {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -89,6 +89,10 @@ const bindOutgoing = ({
           .join('\n');
       }
 
+      if (conversation.getOutgoingMessageMentions(text)) {
+        text = conversation.formatOutgoingMessageMentions(text);
+      }
+
       discordBotClient.input.writeText(text, {
         channelId,
         userId,
@@ -369,13 +373,9 @@ export class DiscordBot extends EventTarget {
         }
         if (conversation) {
 
-          const mentions = conversation.getMessageMentions(text);
           let formattedMessage = text;
-          if (mentions) {
-            console.log('message got mentions', {
-              mentions,
-            });
-            formattedMessage = conversation.formatMessage(text);
+          if (conversation.getIncomingMessageMentions(text)) {
+            formattedMessage = conversation.formatIncomingMessageMentions(text);
           }
 
           const rawMessage = {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/core/chat.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/core/chat.tsx
@@ -10,6 +10,8 @@ export const ChatActions = () => {
         type="say"
         description={dedent`\
           Say something in the chat.
+
+          If you want to mention a player, use the @userId format.
         `}
         schema={
           z.object({

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
@@ -127,7 +127,14 @@ const CharactersPrompt = () => {
       name,
       bio,
     };
-    const agentSpecs = agents.map((agent) => agent.getPlayerSpec());
+    const agentSpecs = agents.map((agent) =>  {
+      const agentSpec = agent.getPlayerSpec() as any;
+      return {
+        name: agentSpec?.name,
+        id: agent.playerId,
+        bio: agentSpec?.bio,
+      };
+    });
 
     const formatAgent = (agent: any) => {
       return [


### PR DESCRIPTION
This PR adds an abstracted chat message user mention support for the Agent's.

Implementation:
- Adds a "mentionsRegex" to the conversation object. This will be used to define the platforms specific mentions format to the conversation.
- The "mentionsRegex" MUST use the named capture group format since that will be used to format the outgoing messages of the agent
- "mentionsRegex" is passed in via the Conversation object constructor through for the binded conversations.
- The Clients also provide the **mentionId** of the user in the Player's spec which is used during the outgoing message formatting
- Incoming messages to the agent are check for having mentions and if mentions are their the message is formatted (using "getIncomingMessageMentions" and "formatOutgoingMessageMentions")
- The formatting currently replaces the platform specific mention with the Player's user id, which is injected message history the prompt
<@12131321321> -> @123asdca-213asdcas-23123
- The "say" action prompt briefs the Agent to use the @userId format for mentioning a user
- The Agent's outgoing messages are formatted by replacing the mentioned userId in the @userId with the platform defined mentionId (from the playerSpec) replacing the named capture group in the platforms defined mentionRegex