### PR TITLE
Fix name field for wrangler toml

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/install-agent.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/install-agent.mjs
@@ -85,7 +85,7 @@ export const installAgent = async (directory) => {
     copyWithStringTransform(srcWranglerToml, dstWranglerToml, (s) => {
       let t = toml.parse(s);
       t = buildWranglerToml(t, {
-        name: agentJson.id,
+        name: `user-agent-${agentJson.id}`,
         // main: `.agents/${name}/main.jsx`,
         // main: `main.jsx`,
       });

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/agent-defaults.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/agent-defaults.mjs
@@ -1,5 +1,5 @@
 import { workersHost } from './util/endpoints.mjs';
 
-export const getAgentName = (guid) => `user-agent-${guid}`;
+export const getAgentName = (guid) => `${guid}`;
 export const getAgentPublicUrl = (guid) => `https://upstreet.ai/agents/${guid}`;
 export const getCloudAgentHost = (guid) => `https://${getAgentName(guid)}.${workersHost}`;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/agent-defaults.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/agent-defaults.mjs
@@ -1,5 +1,5 @@
 import { workersHost } from './util/endpoints.mjs';
 
-export const getAgentName = (guid) => `${guid}`;
+export const getAgentName = (guid) => `user-agent-${guid}`;
 export const getAgentPublicUrl = (guid) => `https://upstreet.ai/agents/${guid}`;
 export const getCloudAgentHost = (guid) => `https://${getAgentName(guid)}.${workersHost}`;


### PR DESCRIPTION
Fix for the wrangler toml name, to use the "user-agent-xxx" syntax as used previously everywhere for the agent cloud url