### PR TITLE
update getAgentName to deploy host format without "user-agent"

### DIFF
--- a/apps/chat/lib/utils.ts
+++ b/apps/chat/lib/utils.ts
@@ -94,7 +94,7 @@ export function getAgentEndpointUrl(guid: string) {
   return `https://user-agent-${guid}.isekaichat.workers.dev/`;
 }
 
-export const getAgentName = (guid: string) => `user-agent-${guid}`;
+export const getAgentName = (guid: string) => `${guid}`;
 export const getAgentHost = (guid: string) => `https://${getAgentName(guid)}.isekaichat.workers.dev`;
 
 export function isValidUrl(urlString: string) {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/agent-defaults.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/agent-defaults.mjs
@@ -1,5 +1,5 @@
 import { workersHost } from './util/endpoints.mjs';
 
-export const getAgentName = (guid) => `user-agent-${guid}`;
+export const getAgentName = (guid) => `${guid}`;
 export const getAgentPublicUrl = (guid) => `https://upstreet.ai/agents/${guid}`;
 export const getCloudAgentHost = (guid) => `https://${getAgentName(guid)}.${workersHost}`;


### PR DESCRIPTION
Current Deployment name only contains the agent id, hence the cloud Agent host with "user-agent" doesnt fetch

![image](https://github.com/user-attachments/assets/c4c3b4bc-5ac8-4acf-998f-0df6a1e9314d)
