### PR TITLE
install upstreet-agent-dep-post-script

### DIFF
--- a/packages/usdk/package.json
+++ b/packages/usdk/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "https://github.com/UpstreetAI/upstreet-core.git"
   },
+  "scripts": {
+    "postinstall": "cd packages/upstreet-agent && npm install --verbose"
+  },
   "bugs": {
     "url": "https://github.com/UpstreetAI/upstreet-core/issues"
   },


### PR DESCRIPTION
Problem:
- Local deps linked via "file:./" are not installed when installing the USDK via npm registry (using npm i usdk -g)
- Install agent symlinks break since the dependancies are not present the usdk upstreet agent dir

Fix:
- Install upstreet-agent deps with a post install script