### PR TITLE
Fix dir naming

### DIFF
--- a/packages/usdk/lib/create.mjs
+++ b/packages/usdk/lib/create.mjs
@@ -438,7 +438,7 @@ export const create = async (args, opts) => {
 
   // update destination directory if no specific path was provided
   if (dstDir === '') {
-    const sanitizedName = agentJson.name.replace(/\s+/g, '_');
+    const sanitizedName = agentJson.name.replace(/[\s#]+/g, '_');
     dstDir = path.join(cwd, sanitizedName);
   }
 


### PR DESCRIPTION
```
The project root contains the "#" character (/Users/og/Documents/PROJECTS/Upstreet/monorepo/packages/usdk/AI_Agent_#55109), which may not work when running Vite. Consider renaming the directory to remove the characters.
The project root contains the "#" character (/Users/og/Documents/PROJECTS/Upstreet/monorepo/packages/usdk/AI_Agent_#55109), which may not work when running Vite. Consider renaming the directory to remove the characters.
Error: Failed to load url entry.mjs (resolved id: entry.mjs). Does the file exist?
    at loadAndTransform (file:///Users/og/Documents/PROJECTS/Upstreet/monorepo/node_modules/.pnpm/vite@5.4.11_@types+node@18.19.68_sass@1.82.0_terser@5.37.0/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:51920:17)
    at async instantiateModule (file:///Users/og/Documents/PROJECTS/Upstreet/monorepo/node_modules/.pnpm/vite@5.4.11_@types+node@18.19.68_sass@1.82.0_terser@5.37.0/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52874:44) {
  code: 'ERR_LOAD_URL'
}
agent crashed with status code 1
```

- Remove # from the default agent dir name ( Ref: sanitizedName in create.mjs )