### PR TITLE
Use DisplayeName for Discord Text Messages

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -366,6 +366,7 @@ export class DiscordBot extends EventTarget {
         const {
           userId,
           username,
+          displayName,
           text,
           channelId, // if there is no channelId, it's a DM
           // XXX discord channel/dm distinction can be made more explicit with a type: string field...
@@ -394,7 +395,7 @@ export class DiscordBot extends EventTarget {
           const id = getIdFromUserId(userId);
           const agent = {
             id,
-            name: username,
+            name: displayName,
           };
           const newMessage = formatConversationMessage(rawMessage, {
             agent,


### PR DESCRIPTION
This PR depends on:
https://github.com/UpstreetAI/upstreet/pull/1451

Use displayName for the text message to maintain consistency with the agent playerSpec.

- Agent spec uses the "displayName" for the discord user
- Incoming messages were using the "username"
- Updated the incoming discord text messages to use the "displayName" to maintain consistency between the Agent spec for the conversation
