### PR TITLE
Update Mention to use User/Agent name instead of Id

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -226,7 +226,7 @@ export class ConversationObject extends EventTarget {
    * @returns {string[] | null} - An array of user IDs or null if no matches are found.
    */
   getOutgoingMessageMentions(message: string): string[] | null {
-    const matches = message.match(/@([0-9a-f-]{36})/g);
+    const matches = message.match(/@(\w+)/g);
     if (!matches) return null;
     
     const result = matches.map(mention => 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -259,8 +259,10 @@ export class ConversationObject extends EventTarget {
           const mentionFormat = this.mentionsRegex.source
             .replace(/\(\?<id>[^)]+\)/, playerSpec.mentionId);
           
+          const sanitizedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
           message = message.replace(
-            new RegExp(`@${name}`, 'g'),
+            new RegExp(`@${sanitizedName}`, 'g'),
             mentionFormat
           );
           break;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -244,25 +244,30 @@ export class ConversationObject extends EventTarget {
    * @returns {string} - The message with mentions formatted for the platform.
    */
   formatOutgoingMessageMentions(message: string): string {
-    const mentions = this.getOutgoingMessageMentions(message);
-    if (mentions && this.mentionsRegex) {
-      mentions.forEach(userId => {
-        const player = this.agentsMap.get(userId);
-        if (player) {
-          const playerSpec = player.getPlayerSpec();
-          if (playerSpec?.mentionId) {
-            // Replace @userId with the platform-specific mention format
-            const mentionFormat = this.mentionsRegex.source
-              .replace(/\(\?<id>[^)]+\)/, playerSpec.mentionId);
-            
-            message = message.replace(
-              new RegExp(`@${userId}`, 'g'),
-              mentionFormat
-            );
-          }
+    // Extract usernames from @mentions in the message
+    const matches = message.match(/@(\w+)/g);
+    if (!matches || !this.mentionsRegex) return message;
+
+    matches.forEach(match => {
+      const username = match.substring(1); // Remove @ symbol
+      
+      // Find player with matching username
+      for (const player of this.agentsMap.values()) {
+        const playerSpec = player.getPlayerSpec();
+        if (playerSpec?.username === username && playerSpec.mentionId) {
+          // Replace @username with platform-specific mention format
+          const mentionFormat = this.mentionsRegex.source
+            .replace(/\(\?<id>[^)]+\)/, playerSpec.mentionId);
+          
+          message = message.replace(
+            new RegExp(`@${username}`, 'g'),
+            mentionFormat
+          );
+          break;
         }
-      });
-    }
+      }
+    });
+
     return message;
   }
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -249,18 +249,18 @@ export class ConversationObject extends EventTarget {
     if (!matches || !this.mentionsRegex) return message;
 
     matches.forEach(match => {
-      const username = match.substring(1); // Remove @ symbol
+      const name = match.substring(1); // Remove @ symbol
       
       // Find player with matching username
       for (const player of this.agentsMap.values()) {
         const playerSpec = player.getPlayerSpec();
-        if (playerSpec?.username === username && playerSpec.mentionId) {
+        if (playerSpec?.name === name && playerSpec.mentionId) {
           // Replace @username with platform-specific mention format
           const mentionFormat = this.mentionsRegex.source
             .replace(/\(\?<id>[^)]+\)/, playerSpec.mentionId);
           
           message = message.replace(
-            new RegExp(`@${username}`, 'g'),
+            new RegExp(`@${name}`, 'g'),
             mentionFormat
           );
           break;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/core/chat.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/core/chat.tsx
@@ -11,7 +11,7 @@ export const ChatActions = () => {
         description={dedent`\
           Say something in the chat.
 
-          If you want to mention a player, use the @username format.
+          If you want to mention a player, use the @name format.
         `}
         schema={
           z.object({

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/core/chat.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/core/chat.tsx
@@ -11,7 +11,7 @@ export const ChatActions = () => {
         description={dedent`\
           Say something in the chat.
 
-          If you want to mention a player, use the @userId format.
+          If you want to mention a player, use the @username format.
         `}
         schema={
           z.object({


### PR DESCRIPTION
Update the Agent to use:

- "@name" format instead of using "@userId" to completely avoid userId's being included in say messages
- update outgoing messages formatting functions to use the agent "name" provided and use their platform mentionId