### PR TITLE
Discord message reactions

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -8,6 +8,7 @@ import {
   PlayableAudioStream,
   GetHashFn,
   MessageCache,
+  MessageReactionEventData,
 } from '../types'
 import { SceneObject } from '../classes/scene-object';
 import { Player } from 'react-agents-client/util/player.mjs';
@@ -358,4 +359,27 @@ export class ConversationObject extends EventTarget {
       }),
     );
   }
+
+
+  async processMessageReaction(
+    reaction,
+    messageId,
+    userId,
+  ) {
+    console.log('process reaction: ',{
+      reaction,
+      messageId,
+      userId,
+    });
+
+    const e = new ExtendableMessageEvent<MessageReactionEventData>('localMessageReaction', {
+      data: {
+        reaction,
+        messageId,
+        userId,
+      },
+    });
+    this.dispatchEvent(e);
+  }
+
 }

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -360,26 +360,24 @@ export class ConversationObject extends EventTarget {
     );
   }
 
+  // async processMessageReaction(
+  //   reaction,
+  //   messageId,
+  //   userId,
+  // ) {
+  //   console.log('process reaction: ',{
+  //     reaction,
+  //     messageId,
+  //     userId,
+  //   });
 
-  async processMessageReaction(
-    reaction,
-    messageId,
-    userId,
-  ) {
-    console.log('process reaction: ',{
-      reaction,
-      messageId,
-      userId,
-    });
-
-    const e = new ExtendableMessageEvent<MessageReactionEventData>('localMessageReaction', {
-      data: {
-        reaction,
-        messageId,
-        userId,
-      },
-    });
-    this.dispatchEvent(e);
-  }
-
+  //   const e = new ExtendableMessageEvent<MessageReactionEventData>('localMessageReaction', {
+  //     data: {
+  //       reaction,
+  //       messageId,
+  //       userId,
+  //     },
+  //   });
+  //   this.dispatchEvent(e);
+  // }
 }

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -421,6 +421,7 @@ export class DiscordBot extends EventTarget {
           messageId,
           emoji,
           channelId,
+          userDisplayName,
         } = e.data;
         console.log('messagereactionadd', {
           userId,
@@ -442,8 +443,25 @@ export class DiscordBot extends EventTarget {
           conversation = this.channelConversations.get(channelId) ?? null;
         }
 
+        const rawMessageReaction = {
+          userId,
+          name: userDisplayName,
+          method: 'messageReaction',
+          args: {
+            reaction: emoji,
+            messageId,
+            userId,
+          },
+        };
+
+        const newMessageReaction = formatConversationMessage(rawMessageReaction, {
+          agent,
+        });
+
+        console.log('newMessageReaction: ', newMessageReaction);
+
         if (conversation) {
-          conversation.processMessageReaction(emoji, messageId, userId);
+          conversation.addLocalMessage(newMessageReaction);
         }
 
       });
@@ -469,10 +487,13 @@ export class DiscordBot extends EventTarget {
           conversation = this.channelConversations.get(channelId) ?? null;
         }
 
+        const newMessageReaction = formatConversationMessage(rawMessageReaction, {
+          agent,
+        });
+        
         if (conversation) {
-          conversation.processMessageReaction(emoji, messageId, userId);
+          conversation.addLocalMessage(newMessageReaction);
         }
-
       });
     };
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -370,6 +370,7 @@ export class DiscordBot extends EventTarget {
           text,
           channelId, // if there is no channelId, it's a DM
           // XXX discord channel/dm distinction can be made more explicit with a type: string field...
+          messageId,
         } = e.data;
 
         // look up conversation
@@ -390,6 +391,7 @@ export class DiscordBot extends EventTarget {
             method: 'say',
             args: {
               text: formattedMessage,
+              messageId,
             },
           };
           const id = getIdFromUserId(userId);
@@ -418,12 +420,32 @@ export class DiscordBot extends EventTarget {
           userId,
           messageId,
           emoji,
+          channelId,
         } = e.data;
         console.log('messagereactionadd', {
           userId,
           messageId,
           emoji,
+          channelId,
         });
+
+        console.log('this.dmConversations: ', this.dmConversations);
+        console.log('this.channelConversations: ', this.channelConversations);
+        console.log('userId: ', userId);
+        console.log('channelId: ', channelId);
+
+         // look up conversation
+        let conversation: ConversationObject | null = null;
+        if (this.dmConversations.has(userId)) {
+          conversation = this.dmConversations.get(userId) ?? null;
+        } else {
+          conversation = this.channelConversations.get(channelId) ?? null;
+        }
+
+        if (conversation) {
+          conversation.processMessageReaction(emoji, messageId, userId);
+        }
+
       });
 
       discordBotClient.output.addEventListener('messagereactionremove', (e: MessageEvent) => {
@@ -431,12 +453,26 @@ export class DiscordBot extends EventTarget {
           userId,
           messageId,
           emoji,
+          channelId,
         } = e.data;
         console.log('messagereactionremove', {
           userId,
           messageId,
           emoji,
+          channelId,
         });
+
+        let conversation: ConversationObject | null = null;
+        if (this.dmConversations.has(userId)) {
+          conversation = this.dmConversations.get(userId) ?? null;
+        } else {
+          conversation = this.channelConversations.get(channelId) ?? null;
+        }
+
+        if (conversation) {
+          conversation.processMessageReaction(emoji, messageId, userId);
+        }
+
       });
     };
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -447,6 +447,9 @@ export class DiscordBot extends EventTarget {
             reaction: emoji,
             messageId,
             userId,
+            context: {
+              action: eventType === 'messagereactionadd' ? 'Reaction added' : 'Reaction removed',
+            },
           },
         };
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -425,6 +425,7 @@ export class DiscordBot extends EventTarget {
         } = e.data;
         console.log('messagereactionadd', {
           userId,
+          userDisplayName,
           messageId,
           emoji,
           channelId,
@@ -470,12 +471,14 @@ export class DiscordBot extends EventTarget {
         const {
           userId,
           messageId,
+          userDisplayName,
           emoji,
           channelId,
         } = e.data;
         console.log('messagereactionremove', {
           userId,
           messageId,
+          userDisplayName,
           emoji,
           channelId,
         });
@@ -487,13 +490,27 @@ export class DiscordBot extends EventTarget {
           conversation = this.channelConversations.get(channelId) ?? null;
         }
 
+       const rawMessageReaction = {
+          userId,
+          name: userDisplayName,
+          method: 'messageReaction',
+          args: {
+            reaction: emoji,
+            messageId,
+            userId,
+          },
+        };
+
         const newMessageReaction = formatConversationMessage(rawMessageReaction, {
           agent,
         });
-        
+
+        console.log('newMessageReaction: ', newMessageReaction);
+
         if (conversation) {
           conversation.addLocalMessage(newMessageReaction);
         }
+
       });
     };
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -411,11 +411,41 @@ export class DiscordBot extends EventTarget {
       });
     };
 
+    // message reactions
+    const _bindIncomingMessageReactions = () => {
+      discordBotClient.output.addEventListener('messagereactionadd', (e: MessageEvent) => {
+        const {
+          userId,
+          messageId,
+          emoji,
+        } = e.data;
+        console.log('messagereactionadd', {
+          userId,
+          messageId,
+          emoji,
+        });
+      });
+
+      discordBotClient.output.addEventListener('messagereactionremove', (e: MessageEvent) => {
+        const {
+          userId,
+          messageId,
+          emoji,
+        } = e.data;
+        console.log('messagereactionremove', {
+          userId,
+          messageId,
+          emoji,
+        });
+      });
+    };
+
     (async () => {
       _bindChannels();
       _bindGuildMemberAdd();
       _bindGuildMemberRemove();
       _bindIncoming();
+      _bindIncomingMessageReactions();
       await _connect();
     })().catch(err => {
       console.warn('discord bot error', err);

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/generative-agent-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/generative-agent-object.ts
@@ -113,7 +113,7 @@ export class GenerativeAgentObject {
   }
   async evaluate(evaluator: Evaluator, opts?: EvaluateOpts) {
     const {
-      sendTyping,
+      sendTyping = true,
     } = opts ?? {};
 
     const evaluateAndExecuteStep = async () => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/generative-agent-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/generative-agent-object.ts
@@ -11,6 +11,7 @@ import type {
   ActionStep,
   Evaluator,
   DebugOptions,
+  EvaluateOpts,
 } from '../types';
 import {
   ConversationObject,
@@ -110,14 +111,28 @@ export class GenerativeAgentObject {
       });
     // });
   }
-  async evaluate(evaluator: Evaluator) {
-    return await this.conversation.typing(async () => {
+  async evaluate(evaluator: Evaluator, opts?: EvaluateOpts) {
+    const {
+      sendTyping,
+    } = opts ?? {};
+
+    const evaluateAndExecuteStep = async () => {
       const step = await evaluator.evaluate({
-        generativeAgent: this,
+        generativeAgent: this as GenerativeAgentObject,
       });
       await executeAgentActionStep(this, step);
       return step;
-    });
+    };
+
+    if (sendTyping) {
+      let result: ActionStep;
+      await this.conversation.typing(async () => {
+        result = await evaluateAndExecuteStep();
+      });
+      return result;
+    } else {
+      return await evaluateAndExecuteStep();
+    }
   }
   /* async generate(hint: string, schema?: ZodTypeAny) {
     // console.log('agent renderer generate 1');

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
@@ -340,6 +340,20 @@ export class DiscordOutput extends EventTarget {
     }
   }
 
+  handleMessageReactionAdd(args) {
+    console.log('handleMessageReactionAdd', args);
+    this.dispatchEvent(new MessageEvent('messagereactionadd', {
+      data: args,
+    }));
+  }
+
+  handleMessageReactionRemove(args) {
+    console.log('handleMessageReactionRemove', args);
+    this.dispatchEvent(new MessageEvent('messagereactionremove', {
+      data: args,
+    }));
+  }
+
   destroy() {
     for (const stream of this.streams.values()) {
       stream.destroy();
@@ -537,17 +551,11 @@ export class DiscordBotClient extends EventTarget {
             break;
           }
           case 'messagereactionadd': {
-            console.log('messagereactionadd', args);
-            this.dispatchEvent(new MessageEvent('messagereactionadd', {
-              data: args,
-            }));
+            this.output.handleMessageReactionAdd(args);
             break;
           }
           case 'messagereactionremove': {
-            console.log('messagereactionremove', args);
-            this.dispatchEvent(new MessageEvent('messagereactionremove', {
-              data: args,
-            }));
+            this.output.handleMessageReactionRemove(args);
             break;
           }
           default: {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
@@ -536,6 +536,20 @@ export class DiscordBotClient extends EventTarget {
             this.input.handleVoiceIdle(args);
             break;
           }
+          case 'messagereactionadd': {
+            console.log('messagereactionadd', args);
+            this.dispatchEvent(new MessageEvent('messagereactionadd', {
+              data: args,
+            }));
+            break;
+          }
+          case 'messagereactionremove': {
+            console.log('messagereactionremove', args);
+            this.dispatchEvent(new MessageEvent('messagereactionremove', {
+              data: args,
+            }));
+            break;
+          }
           default: {
             console.warn('unhandled json method', method);
             break;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/loops/chat-loop.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/loops/chat-loop.tsx
@@ -40,6 +40,24 @@ export const ChatLoop = (props: LoopProps) => {
         priority={-1}
       />
       <Perception
+        type="messageReaction"
+        handler={async (e) => {
+          const { targetAgent } = e.data;
+
+
+          console.log('messageReaction: ', e.data);
+          (async () => {
+            const abortController = new AbortController();
+            const { signal } = abortController;
+            
+            await targetAgent.evaluate(evaluator, {
+              signal,
+            });
+          })();
+        }}
+        priority={-1}
+      />
+      <Perception
         type="nudge"
         handler={async (e) => {
           const { targetAgent, message } = e.data;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/loops/chat-loop.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/loops/chat-loop.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useAgent } from '../hooks';
 import { Perception } from '../components/core/perception';
-import { LoopProps } from '../types';
+import { EvaluateOpts, LoopProps } from '../types';
 import { BasicEvaluator } from '../evaluators/basic-evaluator';
 
 export const ChatLoop = (props: LoopProps) => {
@@ -50,9 +50,12 @@ export const ChatLoop = (props: LoopProps) => {
             const abortController = new AbortController();
             const { signal } = abortController;
             
-            await targetAgent.evaluate(evaluator, {
+            const opts: EvaluateOpts = {
               signal,
-            });
+              sendTyping: false,
+              generativeAgent: targetAgent,
+            };
+            await targetAgent.evaluate(evaluator, opts);
           })();
         }}
         priority={-1}

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
@@ -541,13 +541,23 @@ export const bindConversationToAgent = ({
       })();
     }
   });
-  conversation.addEventListener('localMessageReaction', (e: MessageReactionEvent) => {
+  conversation.addEventListener('localMessageReaction', async (e: MessageReactionEvent) => {
     const { reaction, messageId, userId } = e.data;
     console.log('runtime localMessageReaction: ', {
       reaction,
       messageId,
       userId,
     });
+    try {
+      const {
+          aborted,
+        } = await handleChatPerception(e.data, {
+        agent,
+        conversation,
+      });
+    } catch (error) {
+      console.warn('caught new message reaction error', error);
+    }
   });
 };
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
@@ -541,24 +541,24 @@ export const bindConversationToAgent = ({
       })();
     }
   });
-  conversation.addEventListener('localMessageReaction', async (e: MessageReactionEvent) => {
-    const { reaction, messageId, userId } = e.data;
-    console.log('runtime localMessageReaction: ', {
-      reaction,
-      messageId,
-      userId,
-    });
-    try {
-      const {
-          aborted,
-        } = await handleChatPerception(e.data, {
-        agent,
-        conversation,
-      });
-    } catch (error) {
-      console.warn('caught new message reaction error', error);
-    }
-  });
+  // conversation.addEventListener('localMessageReaction', async (e: MessageReactionEvent) => {
+  //   const { reaction, messageId, userId } = e.data;
+  //   console.log('runtime localMessageReaction: ', {
+  //     reaction,
+  //     messageId,
+  //     userId,
+  //   });
+  //   try {
+  //     const {
+  //         aborted,
+  //       } = await handleChatPerception(e.data, {
+  //       agent,
+  //       conversation,
+  //     });
+  //   } catch (error) {
+  //     console.warn('caught new message reaction error', error);
+  //   }
+  // });
 };
 
 // XXX can move this to the agent renderer

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
@@ -20,6 +20,7 @@ import {
   AbortableMessageEvent,
   PendingActionEventData,
   PerceptionPropsAux,
+  MessageReactionEvent,
 } from './types';
 import {
   PendingActionEvent,
@@ -539,6 +540,14 @@ export const bindConversationToAgent = ({
         });
       })();
     }
+  });
+  conversation.addEventListener('localMessageReaction', (e: MessageReactionEvent) => {
+    const { reaction, messageId, userId } = e.data;
+    console.log('runtime localMessageReaction: ', {
+      reaction,
+      messageId,
+      userId,
+    });
   });
 };
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
@@ -194,6 +194,7 @@ export type EvaluatorOpts = {
 export type EvaluateOpts = {
   generativeAgent: GenerativeAgentObject,
   signal?: AbortSignal,
+  sendTyping?: boolean,
 };
 export type Evaluator = {
   evaluate: (opts: EvaluateOpts) => Promise<ActionStep>;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
@@ -533,6 +533,13 @@ export type ActionMessageEventData = {
 };
 export type ActionMessageEvent = ExtendableMessageEvent<ActionMessageEventData>;
 
+export type MessageReactionEventData = {
+  reaction: string;
+  messageId: string;
+  userId: string;
+};
+export type MessageReactionEvent = ExtendableMessageEvent<MessageReactionEventData>;
+
 export type ConversationChangeEventData = {
   conversation: ConversationObject;
 };


### PR DESCRIPTION
This PR adds discord message reactions support to the Agent's conversation context/history.

Depends on:
https://github.com/UpstreetAI/upstreet/pull/1452

- add's "messagereactionadd" and "messagereactionremove" events (depends on Pr above ^)
- new perception "messageReaction"
- incoming reactions use "messageReaction" method
- reactions added to conversation via addLocalMessage