### PR TITLE
Add app id discord client

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -19,7 +19,7 @@ import { loadMessagesFromDatabase } from '../util/loadMessagesFromDatabase';
 
 export class ConversationObject extends EventTarget {
   agent: ActiveAgentObject; // the current agent
-  agentSpecs: object; // the current agent's spec
+  currentAgentSpecs: object; // the current agent's spec
   agentsMap: Map<string, Player>; // note: agents does not include the current agent
   scene: SceneObject | null;
   getHash: GetHashFn; // XXX this can be a string, since conversation hashes do not change (?)
@@ -47,7 +47,7 @@ export class ConversationObject extends EventTarget {
     this.scene = scene;
     this.getHash = getHash;
     this.mentionsRegex = mentionsRegex;
-    this.agentSpecs = {
+    this.currentAgentSpecs = {
       id: agent.id,
       name: agent.name,
       bio: agent.bio,
@@ -104,17 +104,17 @@ export class ConversationObject extends EventTarget {
     return this.agent;
   }
 
-  setAgentSpec(agentSpec: object) {
-    this.agentSpecs = agentSpec;
+  setCurrentAgentSpecs(agentSpec: object) {
+    this.currentAgentSpecs = agentSpec;
   }
 
-  getAgentSpec() {
-    return this.agentSpecs;
+  getCurrentAgentSpecs() {
+    return this.currentAgentSpecs;
   }
 
-  appendAgentSpec(agentSpec: object) {
-    this.agentSpecs = {
-      ...this.agentSpecs,
+  appendCurrentAgentSpecs(agentSpec: object) {
+    this.currentAgentSpecs = {
+      ...this.currentAgentSpecs,
       ...agentSpec,
     };
   }

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/conversation-object.ts
@@ -19,6 +19,7 @@ import { loadMessagesFromDatabase } from '../util/loadMessagesFromDatabase';
 
 export class ConversationObject extends EventTarget {
   agent: ActiveAgentObject; // the current agent
+  agentSpecs: object; // the current agent's spec
   agentsMap: Map<string, Player>; // note: agents does not include the current agent
   scene: SceneObject | null;
   getHash: GetHashFn; // XXX this can be a string, since conversation hashes do not change (?)
@@ -46,6 +47,11 @@ export class ConversationObject extends EventTarget {
     this.scene = scene;
     this.getHash = getHash;
     this.mentionsRegex = mentionsRegex;
+    this.agentSpecs = {
+      id: agent.id,
+      name: agent.name,
+      bio: agent.bio,
+    };
     this.messageCache = new MessageCacheConstructor({
       loader: async () => {
         const supabase = this.agent.appContextValue.useSupabase();
@@ -96,6 +102,21 @@ export class ConversationObject extends EventTarget {
 
   getAgent() {
     return this.agent;
+  }
+
+  setAgentSpec(agentSpec: object) {
+    this.agentSpecs = agentSpec;
+  }
+
+  getAgentSpec() {
+    return this.agentSpecs;
+  }
+
+  appendAgentSpec(agentSpec: object) {
+    this.agentSpecs = {
+      ...this.agentSpecs,
+      ...agentSpec,
+    };
   }
   // setAgent(agent: ActiveAgentObject) {
   //   this.agent = agent;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -126,6 +126,7 @@ const bindOutgoing = ({
 
 export class DiscordBot extends EventTarget {
   token: string;
+  appId: string;
   channels: DiscordRoomSpec[];
   dms: DiscordRoomSpec[];
   userWhitelist: string[];
@@ -139,6 +140,7 @@ export class DiscordBot extends EventTarget {
     // arguments
     const {
       token,
+      appId,
       channels,
       dms,
       userWhitelist,
@@ -147,6 +149,7 @@ export class DiscordBot extends EventTarget {
       jwt,
     } = args;
     this.token = token;
+    this.appId = appId;
     this.channels = channels;
     this.dms = dms;
     this.userWhitelist = userWhitelist;
@@ -164,6 +167,7 @@ export class DiscordBot extends EventTarget {
     // initialize discord bot client
     const discordBotClient = new DiscordBotClient({
       token,
+      appId,
       codecs,
       jwt,
       name,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -126,7 +126,6 @@ const bindOutgoing = ({
 
 export class DiscordBot extends EventTarget {
   token: string;
-  appId: string;
   channels: DiscordRoomSpec[];
   dms: DiscordRoomSpec[];
   userWhitelist: string[];
@@ -140,7 +139,6 @@ export class DiscordBot extends EventTarget {
     // arguments
     const {
       token,
-      appId,
       channels,
       dms,
       userWhitelist,
@@ -166,7 +164,6 @@ export class DiscordBot extends EventTarget {
     // initialize discord bot client
     const discordBotClient = new DiscordBotClient({
       token,
-      appId,
       codecs,
       jwt,
       name,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -259,6 +259,11 @@ export class DiscordBot extends EventTarget {
             mentionsRegex: discordMentionRegex,
           });
 
+          conversation.appendCurrentAgentSpecs({
+            mentionId: appId,
+          });
+
+
           this.agent.conversationManager.addConversation(conversation);
           this.channelConversations.set(channelId, conversation);
 
@@ -306,6 +311,10 @@ export class DiscordBot extends EventTarget {
           mentionsRegex: discordMentionRegex,
         });
 
+        conversation.appendCurrentAgentSpecs({
+          mentionId: appId,
+        });
+        
         this.agent.conversationManager.addConversation(conversation);
         this.dmConversations.set(userId, conversation);
 

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/classes/discord-manager.ts
@@ -126,6 +126,7 @@ const bindOutgoing = ({
 
 export class DiscordBot extends EventTarget {
   token: string;
+  appId: string;
   channels: DiscordRoomSpec[];
   dms: DiscordRoomSpec[];
   userWhitelist: string[];
@@ -139,6 +140,7 @@ export class DiscordBot extends EventTarget {
     // arguments
     const {
       token,
+      appId,
       channels,
       dms,
       userWhitelist,
@@ -164,6 +166,7 @@ export class DiscordBot extends EventTarget {
     // initialize discord bot client
     const discordBotClient = new DiscordBotClient({
       token,
+      appId,
       codecs,
       jwt,
       name,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -11,6 +11,7 @@ import {
 export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
   const {
     token,
+    appId,
     channels,
     dms,
     userWhitelist,
@@ -25,6 +26,7 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
     if (!conversation) {
       const args: DiscordArgs = {
         token,
+        appId,
         channels: channels ? (Array.isArray(channels) ? channels : [channels]) : [],
         dms: dms ? (Array.isArray(dms) ? dms : [dms]) : [],
         userWhitelist,
@@ -39,6 +41,7 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
     }
   }, [
     token,
+    appId,
     JSON.stringify(channels),
     JSON.stringify(dms),
     JSON.stringify(userWhitelist),

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -14,6 +14,7 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
     channels,
     dms,
     userWhitelist,
+    appId,
   } = props;
   const agent = useAgent();
   const conversation = useConversation();
@@ -31,6 +32,7 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
         agent,
         codecs,
         jwt: authToken,
+        appId,
       };
       const discordBot = agent.discordManager.addDiscordBot(args);
       return () => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -24,6 +24,14 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
 
   useEffect(() => {
     if (!conversation) {
+      
+      if (!token) {
+        throw new Error('Discord Bot token is required');
+      }
+      if (!appId) {
+        throw new Error('Discord Bot appId is required');
+      }
+
       const args: DiscordArgs = {
         token,
         channels: channels ? (Array.isArray(channels) ? channels : [channels]) : [],

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -14,7 +14,6 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
     channels,
     dms,
     userWhitelist,
-    appId,
   } = props;
   const agent = useAgent();
   const conversation = useConversation();

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/plugins/discord.tsx
@@ -24,14 +24,6 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
 
   useEffect(() => {
     if (!conversation) {
-      
-      if (!token) {
-        throw new Error('Discord Bot token is required');
-      }
-      if (!appId) {
-        throw new Error('Discord Bot appId is required');
-      }
-
       const args: DiscordArgs = {
         token,
         channels: channels ? (Array.isArray(channels) ? channels : [channels]) : [],
@@ -40,7 +32,6 @@ export const Discord: React.FC<DiscordProps> = (props: DiscordProps) => {
         agent,
         codecs,
         jwt: authToken,
-        appId,
       };
       const discordBot = agent.discordManager.addDiscordBot(args);
       return () => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
@@ -122,7 +122,7 @@ const CharactersPrompt = () => {
   const bio = usePersonality();
   if (conversation) {
     const agents = conversation.getAgents();
-    const currentAgentSpec = conversation.getAgentSpec();
+    const currentAgentSpec = conversation.getCurrentAgentSpecs();
     const agentSpecs = agents.map((agent) =>  {
       const agentSpec = agent.getPlayerSpec() as any;
       return {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/components/util/default-components.tsx
@@ -122,11 +122,7 @@ const CharactersPrompt = () => {
   const bio = usePersonality();
   if (conversation) {
     const agents = conversation.getAgents();
-    const currentAgentSpec = {
-      id: agent.id,
-      name,
-      bio,
-    };
+    const currentAgentSpec = conversation.getAgentSpec();
     const agentSpecs = agents.map((agent) =>  {
       const agentSpec = agent.getPlayerSpec() as any;
       return {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
@@ -352,7 +352,6 @@ export class DiscordOutput extends EventTarget {
 export class DiscordBotClient extends EventTarget {
   token;
   codecs;
-  appId;
   ws = null;
   input = null; // going from the agent into the discord bot
   output = null; // coming out of the discord bot to the agent
@@ -362,7 +361,6 @@ export class DiscordBotClient extends EventTarget {
 
   constructor({
     token,
-    appId,
     codecs,
     jwt,
     name,
@@ -381,7 +379,6 @@ export class DiscordBotClient extends EventTarget {
 
     this.token = token;
     this.codecs = codecs;
-    this.appId = appId;
     this.input = new DiscordInput();
     this.output = new DiscordOutput({
       codecs,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/lib/discord/discord-client.js
@@ -352,6 +352,7 @@ export class DiscordOutput extends EventTarget {
 export class DiscordBotClient extends EventTarget {
   token;
   codecs;
+  appId;
   ws = null;
   input = null; // going from the agent into the discord bot
   output = null; // coming out of the discord bot to the agent
@@ -361,6 +362,7 @@ export class DiscordBotClient extends EventTarget {
 
   constructor({
     token,
+    appId,
     codecs,
     jwt,
     name,
@@ -379,6 +381,7 @@ export class DiscordBotClient extends EventTarget {
 
     this.token = token;
     this.codecs = codecs;
+    this.appId = appId;
     this.input = new DiscordInput();
     this.output = new DiscordOutput({
       codecs,

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
@@ -121,12 +121,14 @@ export type DiscordRoomSpec = RegExp | string;
 export type DiscordRoomSpecs = DiscordRoomSpec | DiscordRoomSpec[];
 export type DiscordProps = {
   token: string;
+  appId: string;
   channels?: DiscordRoomSpecs;
   dms?: DiscordRoomSpecs;
   userWhitelist?: string[];
 };
 export type DiscordArgs = {
   token: string;
+  appId: string;
   channels: DiscordRoomSpec[];
   dms: DiscordRoomSpec[];
   userWhitelist: string[];

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/types/react-agents.d.ts
@@ -121,14 +121,12 @@ export type DiscordRoomSpec = RegExp | string;
 export type DiscordRoomSpecs = DiscordRoomSpec | DiscordRoomSpec[];
 export type DiscordProps = {
   token: string;
-  appId: string;
   channels?: DiscordRoomSpecs;
   dms?: DiscordRoomSpecs;
   userWhitelist?: string[];
 };
 export type DiscordArgs = {
   token: string;
-  appId: string;
   channels: DiscordRoomSpec[];
   dms: DiscordRoomSpec[];
   userWhitelist: string[];

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features-renderer.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features-renderer.tsx
@@ -287,11 +287,11 @@ export const featureRenderers = {
       <RateLimit maxUserMessages={maxUserMessages} maxUserMessagesTime={maxUserMessagesTime} message={message} />
     );
   },
-  discord: ({token, channels}) => {
+  discord: ({token, appId, channels}) => {
     if (token) {
       channels = channels && channels.map((c: string) => c.trim()).filter(Boolean);
       return (
-        <Discord token={token} channels={channels} />
+        <Discord token={token} appId={appId} channels={channels} />
       );
     } else {
       return null;

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features-renderer.tsx
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/util/agent-features-renderer.tsx
@@ -287,11 +287,11 @@ export const featureRenderers = {
       <RateLimit maxUserMessages={maxUserMessages} maxUserMessagesTime={maxUserMessagesTime} message={message} />
     );
   },
-  discord: ({token, appId, channels}) => {
+  discord: ({token, channels}) => {
     if (token) {
       channels = channels && channels.map((c: string) => c.trim()).filter(Boolean);
       return (
-        <Discord token={token} appId={appId} channels={channels} />
+        <Discord token={token} channels={channels} />
       );
     } else {
       return null;


### PR DESCRIPTION
PR relies/pulls from:
- https://github.com/UpstreetAI/upstreet-core/pull/827
- https://github.com/UpstreetAI/upstreet-core/pull/826/files

Adds "appId" which the Discord Bot (Application/Client Id) to the Agent's conversational playerSpec.
This is to be used to recognize where there is an event directly to the Agent, i.e mentions