### PR TITLE
fix: install agent's package json on build

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/install-agent.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/install-agent.mjs
@@ -4,6 +4,7 @@ import { mkdirp } from 'mkdirp';
 import { rimraf } from 'rimraf';
 import toml from '@iarna/toml';
 import { getCurrentDirname } from '../react-agents/util/path-util.mjs';
+import { npmInstall } from '../../../../lib/npm-util.mjs';
 
 const dirname = getCurrentDirname(import.meta, process);
 const copyWithStringTransform = async (src, dst, transformFn = (s) => s) => {
@@ -96,6 +97,9 @@ export const installAgent = async (directory) => {
     }));
   };
   await removeDependencies();
+
+  // install local dependencies (from the agent's package.json)
+  await npmInstall(directory);
 
   // symlink node_modules deps
   const addDependencies = async () => {


### PR DESCRIPTION
Potentially solves issues where `usdk build` only copied react-agents related `node_modules`, but not locally installed packages in the agent's `package.json`.

Tested locally on my side:
- `usdk build`, worked
- `usdk chat`, worked.
