### PR TITLE
fix: Default generate action step mode

### DIFF
--- a/packages/usdk/packages/upstreet-agent/packages/react-agents-node/install-agent.mjs
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents-node/install-agent.mjs
@@ -4,7 +4,7 @@ import { mkdirp } from 'mkdirp';
 import { rimraf } from 'rimraf';
 import toml from '@iarna/toml';
 import { getCurrentDirname } from '../react-agents/util/path-util.mjs';
-import { npmInstall } from '../../../../lib/npm-util.mjs';
+// import { npmInstall } from '../../../../lib/npm-util.mjs';
 
 const dirname = getCurrentDirname(import.meta, process);
 const copyWithStringTransform = async (src, dst, transformFn = (s) => s) => {
@@ -97,9 +97,6 @@ export const installAgent = async (directory) => {
     }));
   };
   await removeDependencies();
-
-  // install local dependencies (from the agent's package.json)
-  await npmInstall(directory);
 
   // symlink node_modules deps
   const addDependencies = async () => {

--- a/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
+++ b/packages/usdk/packages/upstreet-agent/packages/react-agents/runtime.ts
@@ -79,7 +79,7 @@ const getPrompts = (generativeAgent: GenerativeAgentObject) => {
 export async function generateAgentActionStep({
   generativeAgent,
   hint,
-  mode,
+  mode='basic',
   actOpts,
   debugOpts,
 }: {


### PR DESCRIPTION
I was getting the following error:

```
invalid mode: undefined something
```

Turns out we're not passing any mode to the GenerateActionStep in `monologue` flow, so adding 'basic' as a default in order to prevent errors in other places.

We need to have a better, consistent API for this.