### PR TITLE
fix: preinstall script syntax issue

### DIFF
--- a/packages/usdk/package.json
+++ b/packages/usdk/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "main": "module.mjs",
   "scripts": {
-    "preinstall": "[[ $npm_config_global == 'true' ]] || exit 0; cd packages/upstreet-agent && pnpm install --ignore-workspace --no-frozen-lockfile"
+    "preinstall": "[ \"${npm_config_global:-}\" = 'true' ] || exit 0; cd packages/upstreet-agent && pnpm install --ignore-workspace --no-frozen-lockfile"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
USDK was not properly working in the deployer, because when the dockerfile was being built, the preinstall script would silently fail, and hence the upstreet-agents dependency would be missing.

This ChatGPT chat covers the issue: https://chatgpt.com/share/67975f17-8840-800e-9e83-efa9820780ad

The fix was to update the syntax in the `preinstall` script in usdk's package.json so it could work in posix-compliant operating systems.

Needs testing on Windows.